### PR TITLE
fix: harden conveyor lab docs and build gate

### DIFF
--- a/.github/workflows/conveyor-lab.yml
+++ b/.github/workflows/conveyor-lab.yml
@@ -1,0 +1,44 @@
+name: Conveyor Lab
+
+on:
+  pull_request:
+    paths:
+      - "apps/conveyor-lab/**"
+      - ".github/workflows/conveyor-lab.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/conveyor-lab/**"
+      - ".github/workflows/conveyor-lab.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Backend and frontend build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install backend dependencies
+        working-directory: apps/conveyor-lab/backend
+        run: npm ci
+
+      - name: Build backend
+        working-directory: apps/conveyor-lab/backend
+        run: npm run build
+
+      - name: Install frontend dependencies
+        working-directory: apps/conveyor-lab/frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: apps/conveyor-lab/frontend
+        run: npm run build

--- a/ISSUES_AND_DOC_GAPS.md
+++ b/ISSUES_AND_DOC_GAPS.md
@@ -1,0 +1,104 @@
+# FactoryLM Hub and Conveyor Lab: Issues and Documentation Gaps
+
+## FactoryLM Hub Issues
+
+### 1. Dashboard Placeholder
+- **Location:** `factorylm/apps/dashboard/`
+- **Problem:** Only a stub (`NOT_IMPLEMENTED.md`) – no real UI for monitoring Stardust Racers coaster or the `conv_simple` conveyor cell.
+- **Impact:** No central "one‑glass" view of open faults, dispatch intervals, or conveyor status.
+- **Fix:** Build out the dashboard with real‑time UNS tiles for Stardust block zones and conveyor‑cell panel (PLC tags, VFD status, sensor data). Include assignable fault list with aging timers.
+
+### 2. Lint / React‑Hooks Violations in `mira-hub`
+- **Location:** `MIRA/mira-hub/src/app/(hub)/...`
+- **Specific warnings:**
+  - `admin/users/page.tsx`: `useEffect` calls `setState` synchronously → cascading renders.
+  - `alerts/page.tsx` and `assets/[id]/page.tsx`: Hooks (`useTranslations`, `useState`) called conditionally → breaks Rules of Hooks.
+- **Impact:** Unnecessary re‑runs, possible UI stalls, noisy console.
+- **Fix:**
+  1. Move state updates out of effect bodies (call state inside the async function).
+  2. Ensure every hook call lives at the top level of the component.
+  3. Run `bun run lint` and add a lint step to CI.
+
+### 3. Missing / Noisy Environment Variables (Docker Compose)
+- **Observed warnings:** `TELEGRAM_BOT_TOKEN`, `SLACK_*`, `REDDIT_*`, `APIFY_API_KEY`, `NEON_DATABASE_URL`, `ANTHROPIC_API_KEY`, etc., default to empty strings.
+- **Impact:** Clutters logs, may cause silent failures for integrations.
+- **Fix:**
+  - Populate required secrets via Doppler (`factorylm/prd`) for services that need them.
+  - For optional dev‑only integrations, either provide harmless defaults or guard initialization with `if (!process.env.VAR) return;`.
+  - Document mandatory vars for a minimal dev run.
+
+### 4. Unified Namespace (UNS) Model Gaps
+- **Stardust Racers (coaster):**
+  - Zones (Launch 1/2, Station Load/Unload) are "empty shells" – no live telemetry mapped.
+  - Missing UNS topics for: proximity‑sensor health per block, LSM launch‑ready flags, magnetic‑brake status, dispatch‑interval timers, ride‑stop fault latching.
+- **Conveyor Cell (`conv_simple`):**
+  - Basic asset model present, but live data from Micro820 PLC (motor‑run command, fault codes, Modbus‑TCP comm status) and GS10 VFD (speed, current, accel/decel) not flowing into the UNS.
+  - Sort‑by‑height sensor not modeled.
+- **Impact:** Cannot answer historical fault questions or view real‑time conveyor speed from UNS; tribal knowledge siloed.
+- **Fix:**
+  - Work with controls lead (Reggie) to enumerate exact Modbus tags / IEC‑61131 addresses for each Stardust block and conveyor device.
+  - Add corresponding asset definitions in the UNS (e.g., `uns://factory/Stardust/Launch1/Prox/Health`).
+  - Ensure `diagnosis` or `plc-modbus` service publishes those tags to the UNS (MQTT/Kafka) on change or at suitable intervals.
+  - Have a junior tech (Marcus) build a simple UNS‑viewer widget for the conveyor cell as a learning task.
+
+### 5. CI/CD / Pre‑commit Gaps
+- The lint errors above indicate no automated gate keeping bad patterns out of `mira-hub`.
+- **Fix:**
+  - Add a `lint` step to the project’s CI (GitHub Actions or similar) that runs `bun run lint` and fails on warnings/errors.
+  - Consider a pre‑commit hook (`husky` + `lint‑staged`) for instant feedback before pushing.
+
+## Conveyor Lab Documentation Audit
+
+**Location:** `factorylm/apps/conveyor-lab/`
+**Current files:**
+- `README.md`
+- `backend/` (source)
+- `frontend/` (source)
+
+### Missing / Recommended Documentation Files
+
+| Expected Doc | Why It’s Useful / Typical Content | Status |
+|--------------|-----------------------------------|--------|
+| `CONTRIBUTING.md` | Guidelines for contributors (setup, coding style, PR process, testing). | Missing |
+| `CODE_OF_CONDUCT.md` | Project conduct expectations (often a pointer to a shared repo‑wide file). | Missing |
+| `CONTRIBUTORS` / `AUTHORS` | List of people who have contributed (optional but nice for recognition). | Missing |
+| `DEVELOPMENT.md` or `DEVELOPMENT_GUIDE.md` | Detailed dev setup, linting, testing, building, debugging steps beyond the quick start. | Missing |
+| `ARCHITECTURE.md` | High‑level diagram & description of the HMI/backend/frontend stack, data flow (Modbus ↔ WebSocket ↔ UI). | Missing |
+| `DESIGN.md` | UI/UX rationale (ISA‑101 compliance, color scheme, layout choices). | Missing |
+| `API.md` (or `API_REFERENCE.md`) | Auto‑generated or hand‑written reference for the REST (`/api/*`) and WebSocket (`/ws/telemetry`) endpoints, payloads, error codes. | Missing |
+| `TROUBLESHOOTING.md` / `FAQ.md` | Common issues (Factory I/O not detected, Modbus timeout, voice‑recognition permission problems) and their fixes. | Missing |
+| `CHANGELOG.md` | Chronological list of notable changes per version (helps users/admin track upgrades). | Missing |
+| `LICENSE` | Full license text (MIT is mentioned in README but a standalone file is standard). | Missing |
+| `SECURITY.md` | Instructions for reporting security vulnerabilities (optional but good practice). | Missing |
+| `SUPPORT.md` | Where to get help (e.g., Discord, mailing list, issue tracker). | Missing |
+| `ROADMAP.md` | Planned features or improvements (useful for contributors). | Missing |
+| `STYLE.md` or `CODE_STYLE.md` | Coding conventions (TypeScript/JS, ESLint/Prettier rules) if not fully covered by tooling config. | Missing |
+| `DATA_FLOW.md` or `MODBUS_MAP.md` | Detailed mapping of Modbus registers/coils to the HMI gauges & controls (currently only in README tables). | Missing (could be a subsection of `ARCHITECTURE.md`) |
+
+### Quick Wins for Documentation
+
+1. **Create a `CONTRIBUTING.md`** – point to the existing README for the quick start, then add:
+   - Prerequisites (Node.js, Bun/npm, Factory I/O)
+   - How to run lint (`bun run lint`) and tests (`bun run test`)
+   - Pull‑request checklist (lint passes, tests pass, updated docs if needed)
+   - Coding style (refer to existing ESLint/Prettier config)
+
+2. **Add a minimal `CODE_OF_CONDUCT.md`** – can simply reference the Contributor Covenant v2.1 (or the project‑wide file if one exists).
+
+3. **Copy the MIT license text into a `LICENSE` file** (the repo likely already has one at the root; you can symlink or duplicate it here for clarity).
+
+4. **Extract the Modbus register table** from the README into a dedicated `MODBUS_MAP.md` (or keep it in `ARCHITECTURE.md`) and add a simple diagram of the data flow (Factory I/O ↔ Modbus TCP Client ↔ WebSocket Server ↔ Browser).
+
+5. **Draft a `TROUBLESHOOTING.md`** using the existing “Troubleshooting” section from the README as a starting point, then expand with any additional gotchas you’ve seen while testing.
+
+6. **Consider a `CHANGELOG.md`** – even if the project is still pre‑1.0, logging notable changes (e.g., “added PTT voice control”, “switched to Vite”, “added ISA‑101 theme”) helps contributors and users.
+
+### Next Steps for the Team
+
+- **Assign an owner** (e.g., Marcus – a good “growth” task) to create the missing docs.
+- **Review** the newly added files in a quick PR; ensure they link back to the README where appropriate.
+- **Link** the new docs from the README’s “See also” or “Further reading” section so newcomers discover them easily.
+
+---
+
+**Bottom line:** The biggest blockers right now are the missing dashboard and the UNS gaps – without those you’re still fighting fires blind‑sided. Fix the lint and env‑var noise to keep the dev base clean, then get the UNS populated and the dashboard lit up. Once you’ve got real‑time block‑zone and conveyor data in one place, you’ll spend less time chasing ghosts and more time keeping the line moving.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -6,6 +6,28 @@
 
 ## Session Actions Log
 
+### Session: 2026-06-25 - Conveyor Lab Documentation and Build Gate
+
+**Actions Completed:**
+
+1. **Reviewed `docs/conveyor-lab-and-hub-issues` branch**
+   - Branch added `ISSUES_AND_DOC_GAPS.md` with Conveyor Lab documentation gaps and Hub follow-ups
+   - No open PR existed yet for the `pull/new` URL
+
+2. **Fixed Conveyor Lab build issue**
+   - Backend TypeScript build failed because run summaries used run status `completed` where summary outcome expected `success`
+   - Mapped completed runs to summary outcome `success` while preserving persisted run status `completed`
+
+3. **Documented Conveyor Lab**
+   - Added contributor, development, architecture, API, Modbus map, troubleshooting, security, support, roadmap, style, changelog, code of conduct, and license docs
+   - Updated repo architecture and config docs with Conveyor Lab entrypoints, env vars, and build commands
+
+4. **Added CI coverage**
+   - Added `.github/workflows/conveyor-lab.yml` to build backend and frontend on relevant PRs and main pushes
+
+**Follow-up:**
+- Dashboard and MIRA Hub lint issues from `ISSUES_AND_DOC_GAPS.md` live outside this FactoryLM branch scope and need separate implementation work.
+
 ### Session: 2026-02-12 (Evening) - Bot Fix + Hetzner VPS
 
 **Actions Completed:**

--- a/apps/conveyor-lab/API.md
+++ b/apps/conveyor-lab/API.md
@@ -1,0 +1,123 @@
+# Conveyor Lab API
+
+Base URL: `http://localhost:8888`
+
+## Health
+
+### `GET /api/health`
+
+Returns backend health and WebSocket client count.
+
+```json
+{
+  "status": "ok",
+  "service": "conveyor-lab-backend",
+  "timestamp": 1710000000000,
+  "wsClients": 1
+}
+```
+
+## Status and Commands
+
+### `GET /api/status`
+
+Returns current conveyor status and connection mode.
+
+### `POST /api/command`
+
+Sends a VFD-style command.
+
+```json
+{
+  "action": "set_speed",
+  "value": 30,
+  "runId": "run_123"
+}
+```
+
+Supported actions:
+
+- `start`
+- `stop`
+- `set_speed`
+- `set_direction`
+- `clear_fault`
+- `inject_fault`
+
+`set_direction` expects `value` to be `forward` or `reverse`. `set_speed` expects a number. `inject_fault` is for development and test use only.
+
+## Runs
+
+### `POST /api/runs`
+
+Creates and starts a run.
+
+```json
+{
+  "name": "Demo run",
+  "description": "Factory I/O conveyor test",
+  "direction": "forward",
+  "targetSpeedHz": 30,
+  "maxDurationSeconds": 300,
+  "tags": ["factoryio", "bench"]
+}
+```
+
+### `GET /api/runs`
+
+Lists runs. Optional query parameters:
+
+- `limit`
+- `offset`
+- `tags`
+- `dateFrom`
+- `dateTo`
+
+### `GET /api/runs/:id`
+
+Returns run detail with telemetry, model analysis, feedback, and media.
+
+### `POST /api/runs/:id/stop`
+
+Stops an active run.
+
+### `POST /api/runs/:id/feedback`
+
+Adds operator feedback to a run.
+
+```json
+{
+  "modelAnalysisId": "analysis_123",
+  "actionTaken": "followed",
+  "rating": 5,
+  "tags": ["confirmed"],
+  "notes": "Recommendation matched observed behavior."
+}
+```
+
+### `POST /api/runs/:id/model-analysis`
+
+Stores a precomputed model analysis result.
+
+```json
+{
+  "cosmosModel": "nvidia/cosmos-reason2-2b",
+  "summary": "Conveyor started and reached expected speed.",
+  "suggestedActions": ["Continue monitoring exit sensor timing."],
+  "confidence": 0.82,
+  "reasoning": "Telemetry stayed inside expected range."
+}
+```
+
+## WebSocket
+
+### `/ws/telemetry`
+
+Streams conveyor telemetry and run completion events.
+
+Common message types:
+
+- `status`
+- `telemetry`
+- `runComplete`
+- `error`

--- a/apps/conveyor-lab/ARCHITECTURE.md
+++ b/apps/conveyor-lab/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# Conveyor Lab Architecture
+
+Conveyor Lab is a bench control and telemetry app for the Factory I/O conveyor scene. It is separate from FactoryLM's read-only production diagnostic posture and should not be aimed at production equipment.
+
+## Runtime Shape
+
+```text
+Browser / Telegram Mini App
+  -> Vite frontend
+  -> Express backend REST API
+  -> WebSocket telemetry stream
+  -> Conveyor service
+  -> Factory I/O Modbus TCP adapter or simulator
+```
+
+## Components
+
+| Component | Path | Responsibility |
+|-----------|------|----------------|
+| Frontend | `frontend/src/` | HMI panels, run controls, telemetry views, Telegram Mini App shell |
+| Backend API | `backend/src/index.ts` | Express app, health route, API route mounting, WebSocket server |
+| Status routes | `backend/src/routes/status.ts` | VFD status and control commands |
+| Run routes | `backend/src/routes/runs.ts` | Run creation, history, feedback, model-analysis records |
+| Conveyor service | `backend/src/services/conveyor.ts` | Chooses Factory I/O adapter or simulator mode |
+| Factory I/O adapter | `backend/src/services/modbus-conveyor-adapter.ts` | Modbus TCP reads, writes, telemetry summaries |
+| Simulator | `backend/src/services/conveyor-simulator.ts` | Local conveyor behavior for dev and fallback |
+| In-memory store | `backend/src/models/` | Run, telemetry, feedback, media, and analysis repositories |
+
+## Data Flow
+
+1. The frontend calls `/api/status`, `/api/command`, and `/api/runs`.
+2. The backend chooses Factory I/O mode when Modbus auto-connect succeeds; otherwise it falls back to simulator mode.
+3. Telemetry is published over `/ws/telemetry`.
+4. Run summaries are attached when a run completes, stops, or faults.
+
+## Safety Boundary
+
+Conveyor Lab writes commands to a lab simulator or bench scene. It is not a production PLC control service. Any move toward real equipment needs explicit interlocks, authentication, operator confirmation, and a separate safety review.

--- a/apps/conveyor-lab/CHANGELOG.md
+++ b/apps/conveyor-lab/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## Unreleased
+
+- Added Conveyor Lab contributor, development, architecture, API, troubleshooting, security, support, roadmap, style, and Modbus map documentation.
+- Added a GitHub Actions workflow that builds the Conveyor Lab backend and frontend.
+- Aligned the backend default port with the documented frontend proxy target.
+- Fixed backend run-summary outcome typing so TypeScript builds pass.

--- a/apps/conveyor-lab/CODE_OF_CONDUCT.md
+++ b/apps/conveyor-lab/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Code of Conduct
+
+Conveyor Lab contributors are expected to keep discussions practical, respectful, and focused on making the system safer and easier to operate.
+
+## Expected Behavior
+
+- Assume good intent while still asking for evidence.
+- Keep review comments specific and actionable.
+- Treat safety, security, and hardware-control concerns as blocking until resolved.
+- Avoid sharing private customer data, secrets, or network details in issues or pull requests.
+
+## Unacceptable Behavior
+
+- Harassment, threats, or discriminatory language.
+- Publishing secrets, credentials, private logs, or private plant data.
+- Encouraging unsafe use against production PLCs or uncontrolled machinery.
+
+## Reporting
+
+Report conduct or safety concerns through the repository maintainers. If a report includes a vulnerability or secret, do not open a public issue; use the private security process in [SECURITY.md](SECURITY.md).

--- a/apps/conveyor-lab/CONTRIBUTING.md
+++ b/apps/conveyor-lab/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Conveyor Lab
+
+Conveyor Lab is the FactoryLM bench app for Factory I/O conveyor testing. Keep changes scoped, testable, and safe for a lab simulator before connecting to real hardware.
+
+## Local Setup
+
+```bash
+cd apps/conveyor-lab/backend
+npm ci
+npm run dev
+```
+
+```bash
+cd apps/conveyor-lab/frontend
+npm ci
+npm run dev
+```
+
+Defaults:
+
+- Backend: `http://localhost:8888`
+- Frontend: `http://localhost:3001`
+- WebSocket: `ws://localhost:8888/ws/telemetry`
+
+## Development Rules
+
+- Do not point Conveyor Lab at production PLCs.
+- Prefer simulator mode unless Factory I/O is open and intentionally configured for the test.
+- Keep Modbus address changes mirrored in [MODBUS_MAP.md](MODBUS_MAP.md).
+- Keep API changes mirrored in [API.md](API.md).
+- Do not commit secrets, `.env` files, Telegram tokens, Factory I/O credentials, or private network details.
+
+## Pull Request Checklist
+
+- Backend builds with `cd apps/conveyor-lab/backend && npm run build`.
+- Frontend builds with `cd apps/conveyor-lab/frontend && npm run build`.
+- New or changed env vars are documented in [README.md](README.md) and [../../docs/Config.md](../../docs/Config.md).
+- New endpoints or WebSocket messages are documented in [API.md](API.md).
+- Any hardware-facing behavior includes simulator-safe notes.

--- a/apps/conveyor-lab/DESIGN.md
+++ b/apps/conveyor-lab/DESIGN.md
@@ -1,0 +1,25 @@
+# Conveyor Lab Design Notes
+
+The UI should feel like an industrial HMI, not a marketing page.
+
+## Principles
+
+- Status must be readable at a glance.
+- Controls must make current state, requested state, and fault state distinct.
+- Use compact panels for repeated operational data.
+- Keep colors meaningful and consistent.
+- Avoid decorative animation that could be confused with machine state.
+
+## HMI Color Semantics
+
+| Meaning | Preferred Treatment |
+|---------|---------------------|
+| Running or healthy | Green status lamp |
+| Warning or degraded | Amber status lamp |
+| Fault or unsafe | Red status lamp |
+| Stopped or idle | Neutral gray |
+| Manual action | Button with clear icon and label |
+
+## Mobile Constraints
+
+The Telegram Mini App surface is narrow. Primary controls should stay reachable without horizontal scroll, and telemetry should collapse into scan-friendly rows instead of dense tables.

--- a/apps/conveyor-lab/DEVELOPMENT.md
+++ b/apps/conveyor-lab/DEVELOPMENT.md
@@ -1,0 +1,50 @@
+# Conveyor Lab Development
+
+## Prerequisites
+
+- Node.js 20
+- npm
+- Factory I/O with Modbus TCP/IP Server enabled, or simulator mode
+
+## Run Locally
+
+Backend:
+
+```bash
+cd apps/conveyor-lab/backend
+npm ci
+npm run dev
+```
+
+Frontend:
+
+```bash
+cd apps/conveyor-lab/frontend
+npm ci
+npm run dev
+```
+
+The backend defaults to port `8888`. The frontend defaults to port `3001` and proxies API and WebSocket traffic to `localhost:8888`.
+
+## Useful Environment Variables
+
+```bash
+PORT=8888
+MODBUS_HOST=100.83.251.23
+MODBUS_PORT=502
+MODBUS_UNIT_ID=1
+FACTORYIO_AUTO_CONNECT=true
+TELEGRAM_BOT_TOKEN=
+NODE_ENV=development
+```
+
+Set `FACTORYIO_AUTO_CONNECT=false` to force simulator mode during UI and API development.
+
+## Verification
+
+```bash
+cd apps/conveyor-lab/backend && npm run build
+cd apps/conveyor-lab/frontend && npm run build
+```
+
+The GitHub Actions workflow in `.github/workflows/conveyor-lab.yml` runs both builds for Conveyor Lab changes.

--- a/apps/conveyor-lab/LICENSE
+++ b/apps/conveyor-lab/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) FactoryLM
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/apps/conveyor-lab/MODBUS_MAP.md
+++ b/apps/conveyor-lab/MODBUS_MAP.md
@@ -1,0 +1,40 @@
+# Conveyor Lab Modbus Map
+
+Factory I/O runs as a Modbus TCP server. Conveyor Lab can connect to it directly, or fall back to the simulator when auto-connect is disabled or unavailable.
+
+## Connection
+
+| Setting | Env Var | Default |
+|---------|---------|---------|
+| Host | `MODBUS_HOST` | `100.83.251.23` |
+| Port | `MODBUS_PORT` | `502` |
+| Unit ID | `MODBUS_UNIT_ID` | `1` |
+| Auto-connect | `FACTORYIO_AUTO_CONNECT` | `true` |
+
+## Coils
+
+Digital outputs written by Conveyor Lab.
+
+| Name | Address | Purpose |
+|------|---------|---------|
+| `CONVEYOR` | `0` | Conveyor belt on/off |
+| `FORWARD` | `1` | Forward direction |
+| `REVERSE` | `2` | Reverse direction |
+
+## Discrete Inputs
+
+Digital inputs read from Factory I/O.
+
+| Name | Address | Purpose |
+|------|---------|---------|
+| `RUNNING` | `0` | Conveyor is running |
+| `SENSOR_ENTRY` | `1` | Entry sensor |
+| `SENSOR_EXIT` | `2` | Exit sensor |
+| `AT_ENTRY` | `3` | Part at entry |
+| `AT_EXIT` | `4` | Part at exit |
+
+## Registers
+
+The current basic scene does not map speed setpoints or analog readings to holding or input registers. The UI displays speed in hertz, but Factory I/O speed control is not wired to a register in the current map.
+
+Add any future register mapping here before relying on it in the backend or UI.

--- a/apps/conveyor-lab/README.md
+++ b/apps/conveyor-lab/README.md
@@ -21,7 +21,7 @@ A web-based industrial HMI (Human Machine Interface) that acts as a **second scr
 ### 1. Start the Backend
 ```bash
 cd apps/conveyor-lab/backend
-npm install
+npm ci
 npm run dev
 ```
 Backend starts at **http://localhost:8888**
@@ -29,7 +29,7 @@ Backend starts at **http://localhost:8888**
 ### 2. Start the Frontend
 ```bash
 cd apps/conveyor-lab/frontend
-npm install
+npm ci
 npm run dev
 ```
 Frontend starts at **http://localhost:3001**
@@ -254,6 +254,8 @@ ws.onmessage = (event) => {
 - Ensure backend is running on port 8888
 - Check browser console for CORS errors
 
+For more setup help, see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
 ### Voice Recognition Not Working
 - Use Chrome or Edge browser
 - Grant microphone permissions when prompted
@@ -270,6 +272,7 @@ MODBUS_HOST=100.83.251.23    # Factory I/O IP address
 MODBUS_PORT=502              # Modbus TCP port
 MODBUS_UNIT_ID=1             # Modbus unit ID
 FACTORYIO_AUTO_CONNECT=true  # Auto-detect Factory I/O
+TELEGRAM_BOT_TOKEN=          # Required for production Telegram Mini App auth
 ```
 
 ### Modbus Register Map
@@ -287,6 +290,21 @@ export const MODBUS_MAP = {
   },
 };
 ```
+
+See [MODBUS_MAP.md](MODBUS_MAP.md) for the complete current address map.
+
+---
+
+## Project Docs
+
+- [DEVELOPMENT.md](DEVELOPMENT.md) - local development and verification
+- [ARCHITECTURE.md](ARCHITECTURE.md) - runtime shape and safety boundary
+- [API.md](API.md) - REST and WebSocket API reference
+- [MODBUS_MAP.md](MODBUS_MAP.md) - Factory I/O address mapping
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - common setup failures
+- [SECURITY.md](SECURITY.md) - secrets, auth, and hardware safety
+- [ROADMAP.md](ROADMAP.md) - planned hardening and integration work
+- [STYLE.md](STYLE.md) - UI, TypeScript, and docs conventions
 
 ---
 

--- a/apps/conveyor-lab/ROADMAP.md
+++ b/apps/conveyor-lab/ROADMAP.md
@@ -1,0 +1,26 @@
+# Conveyor Lab Roadmap
+
+## Near Term
+
+- Keep backend and frontend builds green in CI.
+- Add targeted unit tests for command validation, run lifecycle, and simulator telemetry.
+- Replace in-memory repositories with a small persistent store when run history needs to survive restarts.
+- Expand API docs with exact response schemas.
+
+## Lab Integration
+
+- Confirm the Factory I/O scene address map and keep [MODBUS_MAP.md](MODBUS_MAP.md) current.
+- Add clear UI indication for simulator vs Factory I/O mode.
+- Add exportable run telemetry for analysis and demos.
+
+## FactoryLM Integration
+
+- Publish conveyor status into the broader FactoryLM operational model once the UNS boundary is defined.
+- Add a read-only dashboard tile for Conveyor Lab health.
+- Keep write-capable bench controls separate from production diagnostic surfaces.
+
+## Security and Safety
+
+- Harden production Telegram Mini App auth.
+- Add operator confirmation for commands that affect hardware-facing outputs.
+- Document deployment modes and keep simulator mode the default for development.

--- a/apps/conveyor-lab/SECURITY.md
+++ b/apps/conveyor-lab/SECURITY.md
@@ -1,0 +1,30 @@
+# Conveyor Lab Security
+
+Conveyor Lab is intended for Factory I/O and bench testing. Do not connect it to production PLCs or uncontrolled machinery.
+
+## Supported Surface
+
+- Local backend and frontend development
+- Telegram Mini App development with validated init data in production
+- Factory I/O Modbus TCP scenes in a lab network
+- Simulator fallback for offline development
+
+## Reporting a Vulnerability
+
+Do not open a public issue for vulnerabilities, secrets, private network details, or customer data. Contact the repository maintainers privately with:
+
+- A short impact summary
+- Reproduction steps
+- Affected commit or version
+- Logs with secrets removed
+
+## Secret Handling
+
+- Never commit `.env` files.
+- Never commit Telegram bot tokens.
+- Do not paste private plant IPs, VPN details, or customer logs into public issues.
+- Use Doppler or local shell environment variables for runtime secrets.
+
+## Hardware Safety
+
+Any feature that can write to hardware-facing outputs must be reviewed as a safety-sensitive change. Production PLC control requires authentication, explicit operator confirmation, interlocks, and a separate deployment review.

--- a/apps/conveyor-lab/STYLE.md
+++ b/apps/conveyor-lab/STYLE.md
@@ -1,0 +1,21 @@
+# Conveyor Lab Style Guide
+
+## TypeScript
+
+- Keep API payloads validated with schemas before they reach service code.
+- Prefer explicit domain unions for command names, run states, and outcomes.
+- Keep hardware address constants in configuration files, not inline route handlers.
+- Avoid broad `any` types except Express error boundaries.
+
+## UI
+
+- Use compact operational panels.
+- Reserve red, amber, and green for state.
+- Keep primary controls visible on mobile.
+- Do not use decorative motion that resembles machine movement.
+
+## Docs
+
+- Update [API.md](API.md) when routes change.
+- Update [MODBUS_MAP.md](MODBUS_MAP.md) when Factory I/O address mappings change.
+- Update [TROUBLESHOOTING.md](TROUBLESHOOTING.md) when a recurring setup issue is found.

--- a/apps/conveyor-lab/SUPPORT.md
+++ b/apps/conveyor-lab/SUPPORT.md
@@ -1,0 +1,19 @@
+# Conveyor Lab Support
+
+Use GitHub issues for reproducible Conveyor Lab bugs and documentation gaps.
+
+Include:
+
+- Operating system
+- Node.js and npm versions
+- Whether Factory I/O or simulator mode is active
+- Factory I/O scene name and Modbus driver status
+- Backend and frontend command output
+- Browser console errors
+
+Do not include:
+
+- Telegram bot tokens
+- Customer data
+- Private network credentials
+- Unredacted VPN or plant network details

--- a/apps/conveyor-lab/TROUBLESHOOTING.md
+++ b/apps/conveyor-lab/TROUBLESHOOTING.md
@@ -1,0 +1,43 @@
+# Conveyor Lab Troubleshooting
+
+## Backend Starts on the Wrong Port
+
+The backend defaults to `8888`. If another process is using that port:
+
+```bash
+PORT=8890 npm run dev
+```
+
+Update the frontend proxy before using a non-default backend port.
+
+## Factory I/O Does Not Connect
+
+Check:
+
+- Factory I/O is running.
+- The scene has the Modbus TCP/IP Server driver enabled.
+- `MODBUS_HOST` points to the machine running Factory I/O.
+- `MODBUS_PORT` is `502`.
+- Local firewall rules allow inbound Modbus TCP.
+
+To continue without Factory I/O:
+
+```bash
+FACTORYIO_AUTO_CONNECT=false npm run dev
+```
+
+## Commands Do Not Affect the Conveyor
+
+Confirm the address map in [MODBUS_MAP.md](MODBUS_MAP.md) matches the loaded Factory I/O scene. The basic scene currently maps conveyor run and direction through coils and reads status through discrete inputs.
+
+## Telegram Mini App Auth Fails
+
+In development, the backend allows a dev fallback. In production, set `TELEGRAM_BOT_TOKEN` and verify that Telegram init data is present in the Mini App launch context.
+
+## Frontend Cannot Reach API
+
+Verify:
+
+- Backend is running on `http://localhost:8888`.
+- Frontend is running on `http://localhost:3001`.
+- Browser console does not show WebSocket connection errors to `/ws/telemetry`.

--- a/apps/conveyor-lab/backend/src/index.ts
+++ b/apps/conveyor-lab/backend/src/index.ts
@@ -10,7 +10,7 @@
  * - Cosmos model analysis integration (TODO)
  *
  * Environment variables:
- * - PORT: HTTP port (default: 3001)
+ * - PORT: HTTP port (default: 8888)
  * - TELEGRAM_BOT_TOKEN: For validating Mini App init data
  * - DB_PATH: SQLite database path
  * - NODE_ENV: 'development' or 'production'
@@ -25,7 +25,7 @@ import runsRoutes from './routes/runs.js';
 import { telemetryWebSocket } from './services/websocket.js';
 import { initializeConveyor, getConnectionMode } from './services/conveyor.js';
 
-const PORT = parseInt(process.env.PORT || '3001', 10);
+const PORT = parseInt(process.env.PORT || '8888', 10);
 const isDev = process.env.NODE_ENV !== 'production';
 
 // Initialize Express app

--- a/apps/conveyor-lab/backend/src/services/conveyor-simulator.ts
+++ b/apps/conveyor-lab/backend/src/services/conveyor-simulator.ts
@@ -11,7 +11,7 @@
  */
 
 import { EventEmitter } from 'events';
-import type { VFDStatus, Direction, RunState, TelemetryPoint } from '../types/index.js';
+import type { VFDStatus, Direction, RunState, RunSummary, Run, TelemetryPoint } from '../types/index.js';
 import { FAULT_CODES } from '../types/index.js';
 import { telemetryRepo, runRepo } from '../models/repositories.js';
 
@@ -270,6 +270,9 @@ class ConveyorSimulator extends EventEmitter {
     const currents = telemetry.map((t) => t.motorCurrent);
     const faults = telemetry.filter((t) => t.faultCode > 0);
 
+    const summaryOutcome: RunSummary['outcome'] = outcome === 'completed' ? 'success' : outcome;
+    const runStatus: Run['status'] = outcome === 'completed' ? 'completed' : outcome === 'stopped' ? 'stopped' : 'faulted';
+
     const summary = {
       durationSeconds: Math.round((Date.now() - this.runStartTime) / 1000),
       avgSpeedHz: speeds.length > 0 ? speeds.reduce((a, b) => a + b, 0) / speeds.length : 0,
@@ -277,10 +280,10 @@ class ConveyorSimulator extends EventEmitter {
       avgCurrentAmps: currents.length > 0 ? currents.reduce((a, b) => a + b, 0) / currents.length : 0,
       maxCurrentAmps: currents.length > 0 ? Math.max(...currents) : 0,
       faultCount: faults.length,
-      outcome,
+      outcome: summaryOutcome,
     };
 
-    runRepo.updateStatus(runId, outcome === 'completed' ? 'completed' : outcome === 'stopped' ? 'stopped' : 'faulted', summary);
+    runRepo.updateStatus(runId, runStatus, summary);
 
     console.log(`[Simulator] Run ${runId} completed with outcome: ${outcome}`);
     this.state.activeRunId = null;

--- a/apps/conveyor-lab/backend/src/services/modbus-conveyor-adapter.ts
+++ b/apps/conveyor-lab/backend/src/services/modbus-conveyor-adapter.ts
@@ -8,7 +8,7 @@
  */
 
 import { EventEmitter } from 'events';
-import type { VFDStatus, Direction, RunState, TelemetryPoint } from '../types/index.js';
+import type { VFDStatus, Direction, RunState, RunSummary, Run, TelemetryPoint } from '../types/index.js';
 import { FAULT_CODES } from '../types/index.js';
 import { ModbusClient } from './modbus-client.js';
 import { MODBUS_MAP, MODBUS_CONFIG } from '../config/modbus-config.js';
@@ -286,6 +286,9 @@ export class ModbusConveyorAdapter extends EventEmitter {
     const currents = telemetry.map((t) => t.motorCurrent);
     const faults = telemetry.filter((t) => t.faultCode > 0);
 
+    const summaryOutcome: RunSummary['outcome'] = outcome === 'completed' ? 'success' : outcome;
+    const runStatus: Run['status'] = outcome === 'completed' ? 'completed' : outcome === 'stopped' ? 'stopped' : 'faulted';
+
     const summary = {
       durationSeconds: Math.round((Date.now() - this.runStartTime) / 1000),
       avgSpeedHz: speeds.length > 0 ? speeds.reduce((a, b) => a + b, 0) / speeds.length : 0,
@@ -293,14 +296,10 @@ export class ModbusConveyorAdapter extends EventEmitter {
       avgCurrentAmps: currents.length > 0 ? currents.reduce((a, b) => a + b, 0) / currents.length : 0,
       maxCurrentAmps: currents.length > 0 ? Math.max(...currents) : 0,
       faultCount: faults.length,
-      outcome,
+      outcome: summaryOutcome,
     };
 
-    runRepo.updateStatus(
-      runId,
-      outcome === 'completed' ? 'completed' : outcome === 'stopped' ? 'stopped' : 'faulted',
-      summary
-    );
+    runRepo.updateStatus(runId, runStatus, summary);
 
     console.log(`[ModbusAdapter] Run ${runId} completed with outcome: ${outcome}`);
     this.state.activeRunId = null;

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -32,6 +32,7 @@ The repo is a **monorepo** managed by Turborepo, containing apps, services, shar
 | `plc-client-factoryio/` — FactoryIO simulator | Python | ⚠️ **Partial** | Micro820 + FactoryIO + mock PLC clients |
 | `apps/cmms/` — CMMS web app | Java + React/TS | ⚠️ **Forked, not rebranded** | Spring Boot API + React frontend, from grash-cmms |
 | `apps/portal/` — Jarvis brain portal | Node.js | ⚠️ **VPS-specific** | Express server reading `/root/jarvis-workspace/brain` |
+| `apps/conveyor-lab/` — Factory I/O conveyor HMI | Node.js + React/TS | ⚠️ **Working lab app** | Express API, Vite frontend, Factory I/O Modbus adapter, simulator fallback |
 | `apps/dashboard/` | — | 🔴 **Placeholder** | README only |
 | `apps/web/` | — | 🔴 **Stub** | Empty `src/components/` |
 | `services/api/` | — | 🔴 **Placeholder** | README only |
@@ -131,6 +132,7 @@ FactoryLM/
 │   │   ├── api/                  # Java Spring Boot (pom.xml, 650 .java files)
 │   │   └── frontend/             # React 18 + MUI + TypeScript (169 .ts files)
 │   ├── portal/                    # Jarvis brain portal (Express.js, VPS-specific) ⚠️
+│   ├── conveyor-lab/              # Factory I/O conveyor HMI + bench API ⚠️
 │   ├── dashboard/                 # Placeholder (README only) 🔴
 │   └── web/                       # Stub (empty src/components/) 🔴
 │
@@ -184,6 +186,8 @@ FactoryLM/
 | My-Ralph API | `python -m uvicorn api.main:app --reload` (in `My-Ralph/`) | 8000 | ✅ Working |
 | CMMS API | `./mvnw spring-boot:run` (in `apps/cmms/api/`) | ? | ⚠️ Forked, untested in this repo |
 | Jarvis Portal | `node server.js` (in `apps/portal/`) | 3001 | ⚠️ VPS-specific (reads `/root/jarvis-workspace`) |
+| Conveyor Lab backend | `npm run dev` (in `apps/conveyor-lab/backend/`) | 8888 | ⚠️ Lab app, Factory I/O or simulator |
+| Conveyor Lab frontend | `npm run dev` (in `apps/conveyor-lab/frontend/`) | 3001 | ⚠️ Lab HMI |
 
 ### Bots
 
@@ -214,6 +218,8 @@ FactoryLM/
 | My-Ralph tests | `cd My-Ralph && npm test` | 321 |
 | plc-client tests | `cd plc-client && pytest` | ? |
 | plc-client-factoryio tests | `cd plc-client-factoryio && pytest` | ? |
+| Conveyor Lab backend build | `cd apps/conveyor-lab/backend && npm run build` | TypeScript build |
+| Conveyor Lab frontend build | `cd apps/conveyor-lab/frontend && npm run build` | TypeScript + Vite build |
 
 ---
 
@@ -226,6 +232,7 @@ FactoryLM/
 | **DeepSeek** | `core/` | LLM provider |
 | **Google Gemini** | `services/plc-copilot/` | Vision AI for equipment photo ID |
 | **Telegram** | `services/plc-copilot/`, OpenClaw | Bot interface |
+| **Factory I/O** | `apps/conveyor-lab/` | Conveyor bench simulator over Modbus TCP |
 | **Atlas CMMS** | `services/plc-copilot/` | Work order + asset management API |
 | **Axiom** | OpenClaw bots (VPS) | Log aggregation (Vector shippers) |
 | **Honeycomb** | OpenClaw bots (all instances) | Distributed tracing (OTel SDK) |

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -75,6 +75,11 @@ All env vars follow this pattern: `SERVICE_PROVIDER_PURPOSE`
 | `VPS_LEGACY_HOST` | deploy scripts | Hostinger VPS IP (until decommissioned) | factorylm-infra |
 | `PLC_HOST` | plc-modbus | PLC IP address (default: 192.168.1.100) | factorylm-plc |
 | `PLC_PORT` | plc-modbus | Modbus TCP port (default: 502) | factorylm-plc |
+| `PORT` | conveyor-lab backend | HTTP API port (default: 8888) | local shell / future Doppler |
+| `MODBUS_HOST` | conveyor-lab backend | Factory I/O host (default: 100.83.251.23) | local shell / future Doppler |
+| `MODBUS_PORT` | conveyor-lab backend | Factory I/O Modbus TCP port (default: 502) | local shell / future Doppler |
+| `MODBUS_UNIT_ID` | conveyor-lab backend | Factory I/O Modbus unit id (default: 1) | local shell / future Doppler |
+| `FACTORYIO_AUTO_CONNECT` | conveyor-lab backend | Set `false` to force simulator mode | local shell / future Doppler |
 
 ### Accounts (Non-Secret but Tracked)
 
@@ -137,6 +142,23 @@ REGISTRATION_URL=                        # User registration endpoint
 ```
 
 **Test command:** None yet (single-file bot, no tests)
+
+### `apps/conveyor-lab/` — Factory I/O Conveyor HMI
+
+```bash
+# Backend
+PORT=8888
+MODBUS_HOST=100.83.251.23
+MODBUS_PORT=502
+MODBUS_UNIT_ID=1
+FACTORYIO_AUTO_CONNECT=true
+TELEGRAM_BOT_TOKEN=          # Required for production Telegram Mini App auth
+NODE_ENV=development
+```
+
+`FACTORYIO_AUTO_CONNECT=false` forces simulator mode for local UI and API work. `TELEGRAM_BOT_TOKEN` can stay empty in development because the backend has a dev auth fallback, but it is required for production Mini App validation.
+
+**Test command:** `cd apps/conveyor-lab/backend && npm run build && cd ../frontend && npm run build`
 
 ### `scripts/honeycomb/` — OpenTelemetry Tracing
 


### PR DESCRIPTION
## Summary
- add the consolidated Hub and Conveyor Lab issue report without unrelated branch changes
- fix Conveyor Lab backend run-summary outcome typing so the backend TypeScript build passes
- align backend default port with documented/frontend proxy port 8888
- add Conveyor Lab docs for API, architecture, development, Modbus mapping, troubleshooting, security, support, roadmap, style, contributing, changelog, code of conduct, and license
- add a Conveyor Lab GitHub Actions workflow for backend and frontend builds

## Verification
- cd apps/conveyor-lab/backend && npm run build
- cd apps/conveyor-lab/frontend && npm run build
- git diff --check --cached