### PR TITLE
ci: tolerate archived vault note export

### DIFF
--- a/.github/workflows/commit-notes-to-vault.yml
+++ b/.github/workflows/commit-notes-to-vault.yml
@@ -80,5 +80,8 @@ jobs:
             echo "No changes to commit"
           else
             git commit -m "auto: commit notes from factorylm $(date -u +%Y-%m-%d)"
-            git push
+            git push || {
+              echo "::warning::Vault push failed; FactoryLM_OS may be archived or read-only. Skipping non-blocking note export."
+              exit 0
+            }
           fi


### PR DESCRIPTION
## Summary
- make the Commit Notes to Vault push best-effort when the external FactoryLM_OS vault is archived or read-only
- preserve note generation while preventing a non-deploy archive export from failing main

## Verification
- git diff --check
- inspected failed main run 28196807649: push failed with 403 because FactoryLM_OS is archived/read-only