### PR TITLE
[codex] Map PLC canonical tags for Hub UNS

### DIFF
--- a/services/plc-modbus/src/factorylm_plc/modbus_tag_source.py
+++ b/services/plc-modbus/src/factorylm_plc/modbus_tag_source.py
@@ -22,10 +22,111 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 
-from net.models.tags import ERROR_CODES, TagSnapshot
+from .models import ERROR_CODES, TagSnapshot
 
 logger = logging.getLogger(__name__)
+
+STARDUST_ZONES = ("launch_1", "launch_2", "station_load", "station_unload")
+STARDUST_SIGNALS = ("block_occupied", "lsm_ready", "brake_ready", "fault_latched")
+
+REQUIRED_CANONICAL_TAGS = frozenset(
+    {
+        "conv_simple.motor_run",
+        "conv_simple.vfd_speed_hz",
+        "conv_simple.vfd_current_amps",
+        "conv_simple.fault_code",
+        "conv_simple.comm_ok",
+        "conv_simple.height_sensor_mm",
+        "conv_simple.sort_divert_active",
+        *{
+            f"stardust.{zone}.{signal}"
+            for zone in STARDUST_ZONES
+            for signal in STARDUST_SIGNALS
+        },
+    }
+)
+
+CONVEYOR_TAG_ALIASES = {
+    "runcommand": "conv_simple.motor_run",
+    "motorrun": "conv_simple.motor_run",
+    "motor_running": "conv_simple.motor_run",
+    "conveyor_running": "conv_simple.motor_run",
+    "conveyorhz": "conv_simple.vfd_speed_hz",
+    "vfdhz": "conv_simple.vfd_speed_hz",
+    "vfd_hz": "conv_simple.vfd_speed_hz",
+    "vfdspeedhz": "conv_simple.vfd_speed_hz",
+    "vfd_speed_hz": "conv_simple.vfd_speed_hz",
+    "motorcurrentx10": "conv_simple.vfd_current_amps",
+    "motor_current_x10": "conv_simple.vfd_current_amps",
+    "motor_current": "conv_simple.vfd_current_amps",
+    "vfd_current": "conv_simple.vfd_current_amps",
+    "vfd_amps": "conv_simple.vfd_current_amps",
+    "errorcode": "conv_simple.fault_code",
+    "error_code": "conv_simple.fault_code",
+    "fault_code": "conv_simple.fault_code",
+    "vfd_faultcode": "conv_simple.fault_code",
+    "vfd_fault_code": "conv_simple.fault_code",
+    "commok": "conv_simple.comm_ok",
+    "comm_ok": "conv_simple.comm_ok",
+    "vfd_comm_ok": "conv_simple.comm_ok",
+    "heightsensormm": "conv_simple.height_sensor_mm",
+    "height_sensor_mm": "conv_simple.height_sensor_mm",
+    "sortdivertactive": "conv_simple.sort_divert_active",
+    "sort_divert_active": "conv_simple.sort_divert_active",
+}
+
+
+def _normalize_tag_name(raw_name: str) -> str:
+    """Normalize PLC, Ignition, or operator-facing tag labels for matching."""
+    spaced = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", raw_name)
+    return re.sub(r"[^a-z0-9]+", "_", spaced.lower()).strip("_")
+
+
+def canonical_tag_name(raw_name: str) -> str | None:
+    """Map raw PLC/ride tag names to Hub canonical tag names."""
+    normalized = _normalize_tag_name(raw_name)
+    compact = normalized.replace("_", "")
+    conveyor = CONVEYOR_TAG_ALIASES.get(normalized) or CONVEYOR_TAG_ALIASES.get(compact)
+    if conveyor:
+        return conveyor
+
+    if "stardust" not in compact:
+        return None
+
+    zone_match = None
+    for zone in STARDUST_ZONES:
+        zone_compact = zone.replace("_", "")
+        if zone in normalized or zone_compact in compact:
+            zone_match = zone
+            break
+    if zone_match is None:
+        return None
+
+    for signal in STARDUST_SIGNALS:
+        signal_compact = signal.replace("_", "")
+        if signal in normalized or signal_compact in compact:
+            return f"stardust.{zone_match}.{signal}"
+
+    return None
+
+
+def canonical_tags_from_snapshot(snapshot: TagSnapshot) -> dict[str, bool | int | float]:
+    """Project a Micro820 snapshot into the Hub one-board canonical tags."""
+    io = snapshot.io or {}
+    running = bool(snapshot.motor_running or snapshot.conveyor_running)
+    speed_hz = (snapshot.motor_speed or snapshot.conveyor_speed) if running else 0
+
+    return {
+        "conv_simple.motor_run": running,
+        "conv_simple.vfd_speed_hz": int(speed_hz),
+        "conv_simple.vfd_current_amps": float(snapshot.motor_current),
+        "conv_simple.fault_code": int(snapshot.error_code),
+        "conv_simple.comm_ok": int(snapshot.error_code) != 5,
+        "conv_simple.height_sensor_mm": int(io.get("height_sensor_mm", 0)),
+        "conv_simple.sort_divert_active": bool(io.get("sort_divert_active", False)),
+    }
 
 
 class ModbusTagSource:

--- a/services/plc-modbus/src/factorylm_plc/models.py
+++ b/services/plc-modbus/src/factorylm_plc/models.py
@@ -6,7 +6,7 @@ Provides dataclasses for representing machine state with LLM-ready formatting.
 
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 
 
 @dataclass
@@ -61,6 +61,34 @@ ERROR_CODES: Dict[int, str] = {
     4: "Sensor failure",
     5: "Communication loss",
 }
+
+
+@dataclass
+class TagSnapshot:
+    """Point-in-time PLC reading returned by ModbusTagSource."""
+
+    timestamp: str
+    node_id: str
+    motor_running: bool
+    motor_speed: int
+    motor_current: float
+    temperature: float
+    pressure: int
+    conveyor_running: bool
+    conveyor_speed: int
+    sensor_1: bool
+    sensor_2: bool
+    fault_alarm: bool
+    e_stop: bool
+    error_code: int
+    error_message: str
+    coils: list[int] = field(default_factory=list)
+    io: Dict[str, Any] = field(default_factory=dict)
+    e_stop_ok: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert snapshot to a JSON-serializable dictionary."""
+        return asdict(self)
 
 
 @dataclass

--- a/services/plc-modbus/tests/unit/test_modbus_tag_source.py
+++ b/services/plc-modbus/tests/unit/test_modbus_tag_source.py
@@ -1,0 +1,118 @@
+"""Tests for PLC-to-Hub canonical tag projection."""
+
+from datetime import datetime, timezone
+
+from factorylm_plc.modbus_tag_source import (
+    REQUIRED_CANONICAL_TAGS,
+    canonical_tag_name,
+    canonical_tags_from_snapshot,
+)
+from factorylm_plc.models import TagSnapshot
+
+
+def snapshot(**overrides):
+    values = {
+        "timestamp": datetime(2026, 6, 25, 12, 0, tzinfo=timezone.utc).isoformat(),
+        "node_id": "plc-test",
+        "motor_running": True,
+        "motor_speed": 30,
+        "motor_current": 4.5,
+        "temperature": 31.2,
+        "pressure": 100,
+        "conveyor_running": True,
+        "conveyor_speed": 30,
+        "sensor_1": False,
+        "sensor_2": False,
+        "fault_alarm": False,
+        "e_stop": False,
+        "error_code": 0,
+        "error_message": "No error",
+        "coils": [0] * 18,
+        "io": {
+            "height_sensor_mm": 187,
+            "sort_divert_active": True,
+        },
+        "e_stop_ok": True,
+    }
+    values.update(overrides)
+    return TagSnapshot(**values)
+
+
+def test_micro820_snapshot_maps_to_conveyor_canonical_tags():
+    tags = canonical_tags_from_snapshot(snapshot())
+
+    assert tags == {
+        "conv_simple.motor_run": True,
+        "conv_simple.vfd_speed_hz": 30,
+        "conv_simple.vfd_current_amps": 4.5,
+        "conv_simple.fault_code": 0,
+        "conv_simple.comm_ok": True,
+        "conv_simple.height_sensor_mm": 187,
+        "conv_simple.sort_divert_active": True,
+    }
+
+
+def test_comm_fault_snapshot_marks_comm_not_ok_and_fault_code():
+    tags = canonical_tags_from_snapshot(
+        snapshot(motor_running=False, conveyor_running=False, motor_speed=0, error_code=5)
+    )
+
+    assert tags["conv_simple.motor_run"] is False
+    assert tags["conv_simple.vfd_speed_hz"] == 0
+    assert tags["conv_simple.fault_code"] == 5
+    assert tags["conv_simple.comm_ok"] is False
+
+
+def test_raw_stardust_tag_names_map_to_canonical_zone_tags():
+    assert canonical_tag_name("Stardust/Launch 1/Block Occupied") == (
+        "stardust.launch_1.block_occupied"
+    )
+    assert canonical_tag_name("Stardust.Launch2.LSM Ready") == (
+        "stardust.launch_2.lsm_ready"
+    )
+    assert canonical_tag_name("stardust station load brake ready") == (
+        "stardust.station_load.brake_ready"
+    )
+    assert canonical_tag_name("STARDUST_STATION_UNLOAD_FAULT_LATCHED") == (
+        "stardust.station_unload.fault_latched"
+    )
+
+
+def test_raw_conveyor_tag_names_map_to_canonical_tags():
+    assert canonical_tag_name("RunCommand") == "conv_simple.motor_run"
+    assert canonical_tag_name("ConveyorHz") == "conv_simple.vfd_speed_hz"
+    assert canonical_tag_name("MotorCurrentX10") == "conv_simple.vfd_current_amps"
+    assert canonical_tag_name("ErrorCode") == "conv_simple.fault_code"
+    assert canonical_tag_name("VFD_Comm_OK") == "conv_simple.comm_ok"
+    assert canonical_tag_name("HeightSensorMm") == "conv_simple.height_sensor_mm"
+    assert canonical_tag_name("SortDivertActive") == "conv_simple.sort_divert_active"
+
+
+def test_required_canonical_tag_set_matches_task_contract():
+    assert REQUIRED_CANONICAL_TAGS == frozenset(
+        {
+            "conv_simple.motor_run",
+            "conv_simple.vfd_speed_hz",
+            "conv_simple.vfd_current_amps",
+            "conv_simple.fault_code",
+            "conv_simple.comm_ok",
+            "conv_simple.height_sensor_mm",
+            "conv_simple.sort_divert_active",
+            "stardust.launch_1.block_occupied",
+            "stardust.launch_1.lsm_ready",
+            "stardust.launch_1.brake_ready",
+            "stardust.launch_1.fault_latched",
+            "stardust.launch_2.block_occupied",
+            "stardust.launch_2.lsm_ready",
+            "stardust.launch_2.brake_ready",
+            "stardust.launch_2.fault_latched",
+            "stardust.station_load.block_occupied",
+            "stardust.station_load.lsm_ready",
+            "stardust.station_load.brake_ready",
+            "stardust.station_load.fault_latched",
+            "stardust.station_unload.block_occupied",
+            "stardust.station_unload.lsm_ready",
+            "stardust.station_unload.brake_ready",
+            "stardust.station_unload.fault_latched",
+        }
+    )


### PR DESCRIPTION
## Summary
- Adds TagSnapshot support for ModbusTagSource.
- Maps Micro820 snapshots and raw conveyor/Stardust names to canonical Hub tags.
- Adds regression coverage for the Task 4 canonical tag contract.

## Validation
- PYTHONPATH=src pytest tests/unit/test_modbus_tag_source.py -q
- PYTHONPATH=src pytest tests/unit -q

## Notes
- This PR prepares canonical PLC output; relay publishing is planned as the next slice.