### PR TITLE
fix(cmms): allow canonical Atlas browser runtime

### DIFF
--- a/apps/cmms/api/src/main/java/com/grash/configuration/CorsOriginResolver.java
+++ b/apps/cmms/api/src/main/java/com/grash/configuration/CorsOriginResolver.java
@@ -1,0 +1,25 @@
+package com.grash.configuration;
+
+import java.util.Arrays;
+
+public final class CorsOriginResolver {
+
+    private CorsOriginResolver() {
+    }
+
+    public static String[] resolve(String frontendUrl, String configuredOrigins) {
+        String source = configuredOrigins == null || configuredOrigins.trim().isEmpty()
+                ? frontendUrl
+                : configuredOrigins;
+
+        if (source == null || source.trim().isEmpty()) {
+            return new String[0];
+        }
+
+        return Arrays.stream(source.split(","))
+                .map(String::trim)
+                .filter(origin -> !origin.isEmpty())
+                .distinct()
+                .toArray(String[]::new);
+    }
+}

--- a/apps/cmms/api/src/main/java/com/grash/configuration/WebMvcConfig.java
+++ b/apps/cmms/api/src/main/java/com/grash/configuration/WebMvcConfig.java
@@ -22,13 +22,16 @@ public class WebMvcConfig implements WebMvcConfigurer {
     private String frontendUrl;
     @Value("${security.cors.enabled}")
     private boolean enableCors;
+    @Value("${security.cors.allowed-origins:}")
+    private String corsAllowedOrigins;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         if (enableCors) {
             registry.addMapping("/**")
-                    .allowedOrigins(frontendUrl)
+                    .allowedOrigins(CorsOriginResolver.resolve(frontendUrl, corsAllowedOrigins))
                     .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "PATCH", "DELETE")
+                    .allowedHeaders("*")
                     .maxAge(MAX_AGE_SECS);
         } else registry.addMapping("/**").allowedMethods("*");
     }

--- a/apps/cmms/api/src/main/resources/application.yml
+++ b/apps/cmms/api/src/main/resources/application.yml
@@ -81,6 +81,7 @@ security:
   invitation-via-email: ${INVITATION_VIA_EMAIL}
   cors:
     enabled: ${ENABLE_CORS:true}
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
 frontend:
   url: ${PUBLIC_FRONT_URL}
 mail:

--- a/apps/cmms/api/src/test/java/com/grash/configuration/CorsOriginResolverTest.java
+++ b/apps/cmms/api/src/test/java/com/grash/configuration/CorsOriginResolverTest.java
@@ -1,0 +1,35 @@
+package com.grash.configuration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+class CorsOriginResolverTest {
+
+    @Test
+    void resolveUsesFrontendUrlWhenNoOverrideIsConfigured() {
+        assertArrayEquals(
+                new String[]{"https://cmms.factorylm.com"},
+                CorsOriginResolver.resolve("https://cmms.factorylm.com", "")
+        );
+    }
+
+    @Test
+    void resolveSupportsMultipleFallbackOrigins() {
+        assertArrayEquals(
+                new String[]{"http://localhost:3003", "https://cmms.factorylm.com"},
+                CorsOriginResolver.resolve("http://localhost:3003,https://cmms.factorylm.com", "")
+        );
+    }
+
+    @Test
+    void resolveTrimsAndDropsBlankOverrideEntries() {
+        assertArrayEquals(
+                new String[]{"https://app.factorylm.com", "https://cmms.factorylm.com"},
+                CorsOriginResolver.resolve(
+                        "https://ignored.example",
+                        " https://app.factorylm.com, ,https://cmms.factorylm.com "
+                )
+        );
+    }
+}

--- a/apps/cmms/docker-compose.yml
+++ b/apps/cmms/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       DB_PWD: ${POSTGRES_PWD}
       PUBLIC_API_URL: ${PUBLIC_API_URL:-http://localhost:8082}
       PUBLIC_FRONT_URL: ${PUBLIC_FRONT_URL}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-http://localhost:3003,https://cmms.factorylm.com}
       JWT_SECRET_KEY: ${JWT_SECRET_KEY}
       MINIO_ENDPOINT: http://minio:9000
       MINIO_BUCKET: atlas-bucket
@@ -52,10 +53,10 @@ services:
     image: intelloop/atlas-cmms-frontend
     container_name: cmms-frontend
     environment:
-      API_URL: http://165.245.138.91:8082
+      API_URL: ${PUBLIC_API_URL:-http://localhost:8082}
       GOOGLE_KEY: ""
       GOOGLE_TRACKING_ID: ""
-      MUI_X_LICENSE: ""
+      MUI_X_LICENSE: ${MUI_X_LICENSE:-}
       INVITATION_VIA_EMAIL: "false"
       CLOUD_VERSION: "false"
       NODE_ENV: production

--- a/apps/cmms/frontend/src/index.tsx
+++ b/apps/cmms/frontend/src/index.tsx
@@ -16,7 +16,9 @@ import { muiLicense, zendeskKey } from './config';
 import { ZendeskProvider } from 'react-use-zendesk';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
 
-LicenseInfo.setLicenseKey(muiLicense);
+if (muiLicense?.trim()) {
+  LicenseInfo.setLicenseKey(muiLicense);
+}
 
 ReactDOM.render(
   <HelmetProvider>


### PR DESCRIPTION
## Summary
- add configurable Atlas CORS origin resolution with comma-separated origins
- stop the CMMS frontend compose runtime from hardcoding the old public IP and allow deploy env to provide the canonical API URL
- inject `MUI_X_LICENSE` through compose and only call `LicenseInfo.setLicenseKey` when a non-blank key is present
- preserve local compose defaults while also allowing the canonical `https://cmms.factorylm.com` browser origin

Fixes #193
Addresses #192

## Verification
- `docker compose -f apps/cmms/docker-compose.yml config` renders local defaults: `PUBLIC_API_URL=http://localhost:8082`, `API_URL=http://localhost:8082`, `CORS_ALLOWED_ORIGINS=http://localhost:3003,https://cmms.factorylm.com`
- `PUBLIC_FRONT_URL=https://cmms.factorylm.com PUBLIC_API_URL=https://cmms.factorylm.com CORS_ALLOWED_ORIGINS=https://cmms.factorylm.com,https://app.factorylm.com MUI_X_LICENSE=redacted docker compose -f apps/cmms/docker-compose.yml config` renders production-like canonical values
- `git diff --check HEAD~1..HEAD`

## Not run locally
- Maven/JUnit: local machine has no usable Java/Maven runtime
- Frontend install/build: `npm ci` hit ENOSPC in this Codex workspace

## Review
- Subagent review found one compose local-default regression; fixed in commit `e693400` and reviewer confirmed resolved.