### PR TITLE
feat(demo): mission-control promo video pipeline

### DIFF
--- a/ISSUES_AND_DOC_GAPS.md
+++ b/ISSUES_AND_DOC_GAPS.md
@@ -1,0 +1,104 @@
+# FactoryLM Hub and Conveyor Lab: Issues and Documentation Gaps
+
+## FactoryLM Hub Issues
+
+### 1. Dashboard Placeholder
+- **Location:** `factorylm/apps/dashboard/`
+- **Problem:** Only a stub (`NOT_IMPLEMENTED.md`) – no real UI for monitoring Stardust Racers coaster or the `conv_simple` conveyor cell.
+- **Impact:** No central "one‑glass" view of open faults, dispatch intervals, or conveyor status.
+- **Fix:** Build out the dashboard with real‑time UNS tiles for Stardust block zones and conveyor‑cell panel (PLC tags, VFD status, sensor data). Include assignable fault list with aging timers.
+
+### 2. Lint / React‑Hooks Violations in `mira-hub`
+- **Location:** `MIRA/mira-hub/src/app/(hub)/...`
+- **Specific warnings:**
+  - `admin/users/page.tsx`: `useEffect` calls `setState` synchronously → cascading renders.
+  - `alerts/page.tsx` and `assets/[id]/page.tsx`: Hooks (`useTranslations`, `useState`) called conditionally → breaks Rules of Hooks.
+- **Impact:** Unnecessary re‑runs, possible UI stalls, noisy console.
+- **Fix:** 
+  1. Move state updates out of effect bodies (call state inside the async function).
+  2. Ensure every hook call lives at the top level of the component.
+  3. Run `bun run lint` and add a lint step to CI.
+
+### 3. Missing / Noisy Environment Variables (Docker Compose)
+- **Observed warnings:** `TELEGRAM_BOT_TOKEN`, `SLACK_*`, `REDDIT_*`, `APIFY_API_KEY`, `NEON_DATABASE_URL`, `ANTHROPIC_API_KEY`, etc., default to empty strings.
+- **Impact:** Clutters logs, may cause silent failures for integrations.
+- **Fix:** 
+  - Populate required secrets via Doppler (`factorylm/prd`) for services that need them.
+  - For optional dev‑only integrations, either provide harmless defaults or guard initialization with `if (!process.env.VAR) return;`.
+  - Document mandatory vars for a minimal dev run.
+
+### 4. Unified Namespace (UNS) Model Gaps
+- **Stardust Racers (coaster):**
+  - Zones (Launch 1/2, Station Load/Unload) are "empty shells" – no live telemetry mapped.
+  - Missing UNS topics for: proximity‑sensor health per block, LSM launch‑ready flags, magnetic‑brake status, dispatch‑interval timers, ride‑stop fault latching.
+- **Conveyor Cell (`conv_simple`):**
+  - Basic asset model present, but live data from Micro820 PLC (motor‑run command, fault codes, Modbus‑TCP comm status) and GS10 VFD (speed, current, accel/decel) not flowing into the UNS.
+  - Sort‑by‑height sensor not modeled.
+- **Impact:** Cannot answer historical fault questions or view real‑time conveyor speed from UNS; tribal knowledge siloed.
+- **Fix:**
+  - Work with controls lead (Reggie) to enumerate exact Modbus tags / IEC‑61131 addresses for each Stardust block and conveyor device.
+  - Add corresponding asset definitions in the UNS (e.g., `uns://factory/Stardust/Launch1/Prox/Health`).
+  - Ensure `diagnosis` or `plc-modbus` service publishes those tags to the UNS (MQTT/Kafka) on change or at suitable intervals.
+  - Have a junior tech (Marcus) build a simple UNS‑viewer widget for the conveyor cell as a learning task.
+
+### 5. CI/CD / Pre‑commit Gaps
+- The lint errors above indicate no automated gate keeping bad patterns out of `mira-hub`.
+- **Fix:**
+  - Add a `lint` step to the project’s CI (GitHub Actions or similar) that runs `bun run lint` and fails on warnings/errors.
+  - Consider a pre‑commit hook (`husky` + `lint‑staged`) for instant feedback before pushing.
+
+## Conveyor Lab Documentation Audit
+
+**Location:** `factorylm/apps/conveyor-lab/`  
+**Current files:** 
+- `README.md`
+- `backend/` (source)
+- `frontend/` (source)
+
+### Missing / Recommended Documentation Files
+
+| Expected Doc | Why It’s Useful / Typical Content | Status |
+|--------------|-----------------------------------|--------|
+| `CONTRIBUTING.md` | Guidelines for contributors (setup, coding style, PR process, testing). | Missing |
+| `CODE_OF_CONDUCT.md` | Project conduct expectations (often a pointer to a shared repo‑wide file). | Missing |
+| `CONTRIBUTORS` / `AUTHORS` | List of people who have contributed (optional but nice for recognition). | Missing |
+| `DEVELOPMENT.md` or `DEVELOPMENT_GUIDE.md` | Detailed dev setup, linting, testing, building, debugging steps beyond the quick start. | Missing |
+| `ARCHITECTURE.md` | High‑level diagram & description of the HMI/backend/frontend stack, data flow (Modbus ↔ WebSocket ↔ UI). | Missing |
+| `DESIGN.md` | UI/UX rationale (ISA‑101 compliance, color scheme, layout choices). | Missing |
+| `API.md` (or `API_REFERENCE.md`) | Auto‑generated or hand‑written reference for the REST (`/api/*`) and WebSocket (`/ws/telemetry`) endpoints, payloads, error codes. | Missing |
+| `TROUBLESHOOTING.md` / `FAQ.md` | Common issues (Factory I/O not detected, Modbus timeout, voice‑recognition permission problems) and their fixes. | Missing |
+| `CHANGELOG.md` | Chronological list of notable changes per version (helps users/admin track upgrades). | Missing |
+| `LICENSE` | Full license text (MIT is mentioned in README but a standalone file is standard). | Missing |
+| `SECURITY.md` | Instructions for reporting security vulnerabilities (optional but good practice). | Missing |
+| `SUPPORT.md` | Where to get help (e.g., Discord, mailing list, issue tracker). | Missing |
+| `ROADMAP.md` | Planned features or improvements (useful for contributors). | Missing |
+| `STYLE.md` or `CODE_STYLE.md` | Coding conventions (TypeScript/JS, ESLint/Prettier rules) if not fully covered by tooling config. | Missing |
+| `DATA_FLOW.md` or `MODBUS_MAP.md` | Detailed mapping of Modbus registers/coils to the HMI gauges & controls (currently only in README tables). | Missing (could be a subsection of `ARCHITECTURE.md`) |
+
+### Quick Wins for Documentation
+
+1. **Create a `CONTRIBUTING.md`** – point to the existing README for the quick start, then add:
+   - Prerequisites (Node.js, Bun/npm, Factory I/O)
+   - How to run lint (`bun run lint`) and tests (`bun run test`)
+   - Pull‑request checklist (lint passes, tests pass, updated docs if needed)
+   - Coding style (refer to existing ESLint/Prettier config)
+
+2. **Add a minimal `CODE_OF_CONDUCT.md`** – can simply reference the Contributor Covenant v2.1 (or the project‑wide file if one exists).
+
+3. **Copy the MIT license text into a `LICENSE` file** (the repo likely already has one at the root; you can symlink or duplicate it here for clarity).
+
+4. **Extract the Modbus register table** from the README into a dedicated `MODBUS_MAP.md` (or keep it in `ARCHITECTURE.md`) and add a simple diagram of the data flow (Factory I/O ↔ Modbus TCP Client ↔ WebSocket Server ↔ Browser).
+
+5. **Draft a `TROUBLESHOOTING.md`** using the existing “Troubleshooting” section from the README as a starting point, then expand with any additional gotchas you’ve seen while testing.
+
+6. **Consider a `CHANGELOG.md`** – even if the project is still pre‑1.0, logging notable changes (e.g., “added PTT voice control”, “switched to Vite”, “added ISA‑101 theme”) helps contributors and users.
+
+### Next Steps for the Team
+
+- **Assign an owner** (e.g., Marcus – a good “growth” task) to create the missing docs.
+- **Review** the newly added files in a quick PR; ensure they link back to the README where appropriate.
+- **Link** the new docs from the README’s “See also” or “Further reading” section so newcomers discover them easily.
+
+---
+
+**Bottom line:** The biggest blockers right now are the missing dashboard and the UNS gaps – without those you’re still fighting fires blind‑sided. Fix the lint and env‑var noise to keep the dev base clean, then get the UNS populated and the dashboard lit up. Once you’ve got real‑time block‑zone and conveyor data in one place, you’ll spend less time chasing ghosts and more time keeping the line moving.

--- a/apps/mission-control/.gitignore
+++ b/apps/mission-control/.gitignore
@@ -1,0 +1,9 @@
+demo/auth.json
+demo/raw/
+demo/audio/
+demo/final_demo.mp4
+demo/tabs/*/raw/
+demo/tabs/*/audio/
+demo/tabs/**/*.mp4
+demo/tabs/**/*.webm
+node_modules/

--- a/apps/mission-control/demo/login.mjs
+++ b/apps/mission-control/demo/login.mjs
@@ -1,0 +1,81 @@
+/**
+ * Mission Control — One-Time Login
+ *
+ * Logs in to the production Hub, saves the session to auth.json.
+ * Run once; auth.json is reused by record_tab.mjs for all 8 recordings.
+ *
+ * Usage:
+ *   HUB_EMAIL=you@factorylm.com HUB_PASSWORD=secret node demo/login.mjs
+ *
+ * Or via Doppler:
+ *   doppler run -p factorylm -c dev -- node demo/login.mjs
+ *   (requires HUB_EMAIL and HUB_PASSWORD in that Doppler config)
+ */
+
+import { chromium } from 'playwright'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const AUTH_PATH = join(__dirname, 'auth.json')
+const HUB_URL = process.env.HUB_URL || 'https://app.factorylm.com'
+
+const email = process.env.HUB_EMAIL
+const password = process.env.HUB_PASSWORD
+
+if (!email || !password) {
+  console.error('ERROR: Set HUB_EMAIL and HUB_PASSWORD env vars')
+  console.error('  HUB_EMAIL=you@factorylm.com HUB_PASSWORD=secret node demo/login.mjs')
+  process.exit(1)
+}
+
+const browser = await chromium.launch({ headless: false })
+const ctx = await browser.newContext({ viewport: { width: 1920, height: 1080 } })
+const page = await ctx.newPage()
+
+console.log(`Navigating to ${HUB_URL} …`)
+await page.goto(HUB_URL, { waitUntil: 'domcontentloaded' })
+await page.waitForTimeout(2000)
+
+// The "Sign in with password" accordion must be clicked first
+console.log('Expanding password login form …')
+const expandBtn = page.locator('button[aria-controls="password-signin-form"]')
+if (await expandBtn.count() > 0) {
+  await expandBtn.click()
+  await page.waitForTimeout(600)
+}
+
+// Fill the expanded password form
+const passwordInput = page.locator('input[type="password"]').first()
+await passwordInput.waitFor({ timeout: 10000 })
+
+// The password form has its own email field; prefer the one inside the expanded section
+const emailInPasswordForm = page.locator('#password-signin-form input[type="email"], #password-signin-form input[name="email"]').first()
+const emailInput = (await emailInPasswordForm.count() > 0)
+  ? emailInPasswordForm
+  : page.locator('input[type="email"], input[name="email"]').last()
+
+console.log('Filling credentials …')
+await emailInput.fill(email)
+await passwordInput.fill(password)
+await page.keyboard.press('Enter')
+
+console.log('Waiting for post-login redirect …')
+try {
+  // Wait for URL to change away from login page
+  await page.waitForURL(url => !url.toString().includes('login') && !url.toString().includes('signin'), {
+    timeout: 20000,
+  })
+} catch (_) {
+  // If no URL change, just wait for the page to settle
+  await page.waitForTimeout(4000)
+}
+
+const finalUrl = page.url()
+console.log(`Landed at: ${finalUrl}`)
+
+await ctx.storageState({ path: AUTH_PATH })
+await browser.close()
+
+console.log(`\nauth.json saved → ${AUTH_PATH}`)
+console.log('Run recordings with: node demo/record_tab.mjs <slug>')

--- a/apps/mission-control/demo/record.mjs
+++ b/apps/mission-control/demo/record.mjs
@@ -1,0 +1,206 @@
+/**
+ * Mission Control Demo Recorder
+ *
+ * Drives the live app via Playwright, pausing on each feature for
+ * exactly as long as the narration segment lasts, then records the
+ * full session as a webm video.
+ *
+ * Usage:
+ *   # From repo root:
+ *   node apps/mission-control/demo/record.mjs
+ *
+ * Prerequisites:
+ *   cd apps/mission-control/frontend && npm install playwright
+ *   npx playwright install chromium
+ *   Mission Control backend running: uvicorn backend.main:app --port 8090
+ */
+
+import { chromium } from 'playwright'
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { dirname, join, resolve } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const BASE_URL = 'http://localhost:8090'
+const SCRIPT_PATH = join(__dirname, 'script.md')
+const RAW_DIR = join(__dirname, 'raw')
+const TIMECODES_PATH = join(__dirname, 'timecodes.json')
+
+mkdirSync(RAW_DIR, { recursive: true })
+
+// ---------------------------------------------------------------------------
+// Script parser
+// ---------------------------------------------------------------------------
+
+function parseTimestamp(ts) {
+  const [h, m, s] = ts.split(':').map(Number)
+  return h * 3600 + m * 60 + s
+}
+
+function parseScript(path) {
+  const lines = readFileSync(path, 'utf8').split('\n')
+  const segments = []
+
+  for (const line of lines) {
+    const match = line.match(/^\[(\d{2}:\d{2}:\d{2})\]\s+\[([^\]]+)\]\s+(.+)$/)
+    if (!match) continue
+    const [, ts, action, narration] = match
+    segments.push({ ts, t: parseTimestamp(ts), action: action.trim(), narration: narration.trim() })
+  }
+
+  // Compute duration_s for each segment from next segment's timestamp
+  for (let i = 0; i < segments.length; i++) {
+    if (i < segments.length - 1) {
+      segments[i].duration_s = segments[i + 1].t - segments[i].t
+    } else {
+      segments[i].duration_s = 0
+    }
+  }
+
+  return segments.filter(s => s.action !== 'END')
+}
+
+// ---------------------------------------------------------------------------
+// Action executor
+// ---------------------------------------------------------------------------
+
+async function executeAction(page, action) {
+  if (action === 'PAUSE') return
+
+  if (action.startsWith('NAV:')) {
+    const route = action.slice(4)
+    // Prefer clicking the sidebar link — more visually demonstrative than goto
+    const routeToLabel = {
+      '/': 'Chat Relay',
+      '/dashboard': 'Dashboard',
+      '/terminal': 'Terminal',
+      '/workers': 'Worker Swarm',
+      '/ralph': 'Ralph Loop',
+      '/agents': 'Agents',
+      '/tools': 'Tools',
+      '/hub': 'Ladder Logic',
+    }
+    const label = routeToLabel[route]
+    if (label) {
+      try {
+        await page.click(`a:has-text("${label}")`, { timeout: 3000 })
+        await page.waitForTimeout(800) // let React render
+        return
+      } catch (_) { /* fall through to goto */ }
+    }
+    await page.goto(`${BASE_URL}${route}`, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(800)
+    return
+  }
+
+  if (action.startsWith('CLICK:')) {
+    const selector = action.slice(6)
+    try {
+      await page.click(selector, { timeout: 2000 })
+    } catch (_) {
+      console.warn(`  WARN: CLICK failed for selector: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('FILL:')) {
+    // Format: FILL:selector:value (value may contain colons)
+    const rest = action.slice(5)
+    const colonIdx = rest.indexOf(':')
+    if (colonIdx === -1) return
+    const selector = rest.slice(0, colonIdx)
+    const value = rest.slice(colonIdx + 1)
+    try {
+      await page.fill(selector, value, { timeout: 2000 })
+    } catch (_) {
+      console.warn(`  WARN: FILL failed for selector: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('HOVER:')) {
+    const selector = action.slice(6)
+    try {
+      await page.hover(selector, { timeout: 2000 })
+    } catch (_) {
+      console.warn(`  WARN: HOVER failed for selector: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('SCROLL:')) {
+    const delta = parseInt(action.slice(7), 10)
+    await page.evaluate((dy) => window.scrollBy({ top: dy, behavior: 'smooth' }), delta)
+    await page.waitForTimeout(400) // let smooth scroll settle
+    return
+  }
+
+  console.warn(`  WARN: Unknown action: ${action}`)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const segments = parseScript(SCRIPT_PATH)
+  console.log(`\nMission Control Demo Recorder`)
+  console.log(`Segments: ${segments.length}`)
+  console.log(`Estimated duration: ${segments.reduce((a, s) => a + s.duration_s, 0)}s`)
+  console.log(`Video output: ${RAW_DIR}/\n`)
+
+  const browser = await chromium.launch({
+    headless: false,
+    args: ['--start-maximized'],
+  })
+
+  const ctx = await browser.newContext({
+    recordVideo: {
+      dir: RAW_DIR,
+      size: { width: 1920, height: 1080 },
+    },
+    viewport: { width: 1920, height: 1080 },
+  })
+
+  const page = await ctx.newPage()
+
+  // Initial load
+  await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('aside', { timeout: 10000 })
+  await page.waitForTimeout(1500) // let React hydrate
+
+  const timecodes = []
+
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i]
+    const pct = Math.round(((i + 1) / segments.length) * 100)
+    console.log(`[${String(i + 1).padStart(2, '0')}/${segments.length}] ${seg.ts} [${seg.action}] (${seg.duration_s}s) — ${seg.narration.slice(0, 60)}…`)
+
+    await executeAction(page, seg.action)
+
+    // Record timecode for A/V sync reference
+    timecodes.push({ t: seg.t, duration_s: seg.duration_s, narration: seg.narration })
+
+    // Hold on this feature for the duration of the narration segment
+    if (seg.duration_s > 0) {
+      await page.waitForTimeout(seg.duration_s * 1000)
+    }
+  }
+
+  // Write timecodes sidecar for sync reference
+  writeFileSync(TIMECODES_PATH, JSON.stringify(timecodes, null, 2))
+  console.log(`\nTimecodes written: ${TIMECODES_PATH}`)
+
+  await ctx.close()
+  await browser.close()
+
+  console.log(`\nDone. Raw video saved to: ${RAW_DIR}/`)
+  console.log(`Next step: node demo/voice.py  →  bash demo/sync.sh`)
+}
+
+main().catch(err => {
+  console.error('\nFATAL:', err.message)
+  console.error('Is Mission Control running at', BASE_URL, '?')
+  console.error('Have you run: npx playwright install chromium ?')
+  process.exit(1)
+})

--- a/apps/mission-control/demo/record_tab.mjs
+++ b/apps/mission-control/demo/record_tab.mjs
@@ -1,0 +1,217 @@
+/**
+ * Mission Control — Per-Tab Promo Recorder
+ *
+ * Records a single tab's promo video from the live production site.
+ * Reads demo/tabs/<slug>/script.md, drives the UI, outputs webm.
+ *
+ * Usage:
+ *   node demo/record_tab.mjs <slug>
+ *
+ * Slugs:
+ *   01_chat_relay   02_dashboard   03_terminal   04_worker_swarm
+ *   05_ralph_loop   06_agents      07_tools       08_hub
+ *
+ * Prerequisites:
+ *   1. node demo/login.mjs  →  demo/auth.json must exist
+ *   2. Playwright chromium installed: npx playwright install chromium
+ *
+ * Env vars:
+ *   HUB_URL   Base URL of the Hub (default: https://app.factorylm.com)
+ */
+
+import { chromium } from 'playwright'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const HUB_URL = process.env.HUB_URL || 'https://app.factorylm.com'
+const AUTH_PATH = join(__dirname, 'auth.json')
+
+const TAB_META = {
+  '01_chat_relay':   { label: 'Chat Relay',   route: '/' },
+  '02_dashboard':    { label: 'Dashboard',    route: '/dashboard' },
+  '03_terminal':     { label: 'Terminal',     route: '/terminal' },
+  '04_worker_swarm': { label: 'Worker Swarm', route: '/workers' },
+  '05_ralph_loop':   { label: 'Ralph Loop',   route: '/ralph' },
+  '06_agents':       { label: 'Agents',       route: '/agents' },
+  '07_tools':        { label: 'Tools',        route: '/tools' },
+  '08_hub':          { label: 'Ladder Logic', route: '/hub' },
+}
+
+// ---------------------------------------------------------------------------
+// Arg validation
+// ---------------------------------------------------------------------------
+
+const slug = process.argv[2]
+if (!slug || !TAB_META[slug]) {
+  console.error(`Usage: node demo/record_tab.mjs <slug>`)
+  console.error(`Slugs: ${Object.keys(TAB_META).join('  ')}`)
+  process.exit(1)
+}
+
+if (!existsSync(AUTH_PATH)) {
+  console.error(`ERROR: ${AUTH_PATH} not found.`)
+  console.error('Run: HUB_EMAIL=x HUB_PASSWORD=y node demo/login.mjs')
+  process.exit(1)
+}
+
+const { label, route } = TAB_META[slug]
+const TAB_DIR = join(__dirname, 'tabs', slug)
+const SCRIPT_PATH = join(TAB_DIR, 'script.md')
+const RAW_DIR = join(TAB_DIR, 'raw')
+const TIMECODES_PATH = join(TAB_DIR, 'timecodes.json')
+
+mkdirSync(RAW_DIR, { recursive: true })
+
+// ---------------------------------------------------------------------------
+// Script parser (same as record.mjs)
+// ---------------------------------------------------------------------------
+
+function parseTimestamp(ts) {
+  const [h, m, s] = ts.split(':').map(Number)
+  return h * 3600 + m * 60 + s
+}
+
+function parseScript(path) {
+  const lines = readFileSync(path, 'utf8').split('\n')
+  const segments = []
+  for (const line of lines) {
+    const match = line.match(/^\[(\d{2}:\d{2}:\d{2})\]\s+\[([^\]]+)\]\s+(.+)$/)
+    if (!match) continue
+    const [, ts, action, narration] = match
+    segments.push({ ts, t: parseTimestamp(ts), action: action.trim(), narration: narration.trim() })
+  }
+  for (let i = 0; i < segments.length; i++) {
+    segments[i].duration_s = i < segments.length - 1
+      ? segments[i + 1].t - segments[i].t
+      : 0
+  }
+  return segments.filter(s => s.action !== 'END')
+}
+
+// ---------------------------------------------------------------------------
+// Action executor — same as record.mjs but with production-safe selectors
+// ---------------------------------------------------------------------------
+
+async function executeAction(page, action) {
+  if (action === 'PAUSE') return
+
+  if (action.startsWith('NAV:')) {
+    const routeKey = action.slice(4)
+    // Try sidebar NavLink click first (works regardless of base URL structure)
+    const linkLabel = Object.values(TAB_META).find(m => m.route === routeKey)?.label
+    if (linkLabel) {
+      try {
+        await page.click(`a:has-text("${linkLabel}")`, { timeout: 3000 })
+        await page.waitForTimeout(800)
+        return
+      } catch (_) {}
+    }
+    // Fallback: goto relative to current origin
+    const origin = new URL(page.url()).origin
+    await page.goto(`${origin}${routeKey}`, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(800)
+    return
+  }
+
+  if (action.startsWith('CLICK:')) {
+    const selector = action.slice(6)
+    try { await page.click(selector, { timeout: 2000 }) } catch (_) {
+      console.warn(`  WARN: CLICK failed: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('FILL:')) {
+    const rest = action.slice(5)
+    const colonIdx = rest.indexOf(':')
+    if (colonIdx === -1) return
+    const selector = rest.slice(0, colonIdx)
+    const value = rest.slice(colonIdx + 1)
+    try { await page.fill(selector, value, { timeout: 2000 }) } catch (_) {
+      console.warn(`  WARN: FILL failed: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('HOVER:')) {
+    const selector = action.slice(6)
+    try { await page.hover(selector, { timeout: 2000 }) } catch (_) {
+      console.warn(`  WARN: HOVER failed: ${selector}`)
+    }
+    return
+  }
+
+  if (action.startsWith('SCROLL:')) {
+    const delta = parseInt(action.slice(7), 10)
+    await page.evaluate((dy) => window.scrollBy({ top: dy, behavior: 'smooth' }), delta)
+    await page.waitForTimeout(400)
+    return
+  }
+
+  console.warn(`  WARN: Unknown action: ${action}`)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const segments = parseScript(SCRIPT_PATH)
+const totalDuration = segments.reduce((a, s) => a + s.duration_s, 0)
+
+console.log(`\nMission Control — Recording: ${slug} (${label})`)
+console.log(`Segments  : ${segments.length}`)
+console.log(`Duration  : ${totalDuration}s (~${Math.round(totalDuration / 60)}min)`)
+console.log(`Target    : ${HUB_URL}`)
+console.log(`Video out : ${RAW_DIR}/\n`)
+
+const browser = await chromium.launch({
+  headless: false,
+  args: ['--start-maximized'],
+})
+
+const ctx = await browser.newContext({
+  storageState: AUTH_PATH,
+  recordVideo: {
+    dir: RAW_DIR,
+    size: { width: 1920, height: 1080 },
+  },
+  viewport: { width: 1920, height: 1080 },
+})
+
+const page = await ctx.newPage()
+
+// Navigate to Hub root, then to the correct tab
+await page.goto(HUB_URL, { waitUntil: 'domcontentloaded' })
+await page.waitForTimeout(2000)
+
+// Navigate to this tab via sidebar click
+try {
+  await page.click(`a:has-text("${label}")`, { timeout: 5000 })
+  await page.waitForTimeout(1500)
+} catch (_) {
+  console.warn(`  WARN: Could not click sidebar link for "${label}" — proceeding from root`)
+}
+
+const timecodes = []
+
+for (let i = 0; i < segments.length; i++) {
+  const seg = segments[i]
+  console.log(`[${String(i + 1).padStart(2, '0')}/${segments.length}] ${seg.ts} [${seg.action}] (${seg.duration_s}s)`)
+
+  await executeAction(page, seg.action)
+  timecodes.push({ t: seg.t, duration_s: seg.duration_s, narration: seg.narration })
+
+  if (seg.duration_s > 0) {
+    await page.waitForTimeout(seg.duration_s * 1000)
+  }
+}
+
+writeFileSync(TIMECODES_PATH, JSON.stringify(timecodes, null, 2))
+
+await ctx.close()
+await browser.close()
+
+console.log(`\nDone. Video → ${RAW_DIR}/`)
+console.log(`Next: TTS_PROVIDER=macos python demo/voice.py --tab ${slug}`)

--- a/apps/mission-control/demo/run_all.sh
+++ b/apps/mission-control/demo/run_all.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Mission Control — Record All 8 Promo Videos
+#
+# Runs the full pipeline (record → voice → merge) for every tab.
+# auth.json must already exist: run node demo/login.mjs first.
+#
+# Usage (from apps/mission-control/):
+#   TTS_PROVIDER=macos bash demo/run_all.sh
+#   TTS_PROVIDER=elevenlabs bash demo/run_all.sh
+#
+# To re-run a single tab:
+#   node demo/record_tab.mjs 02_dashboard
+#   TTS_PROVIDER=macos python demo/voice.py --tab 02_dashboard
+#   bash demo/sync_tab.sh 02_dashboard
+
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROVIDER=${TTS_PROVIDER:-macos}
+
+TABS=(
+  "01_chat_relay"
+  "02_dashboard"
+  "03_terminal"
+  "04_worker_swarm"
+  "05_ralph_loop"
+  "06_agents"
+  "07_tools"
+  "08_hub"
+)
+
+if [ ! -f "$DEMO_DIR/auth.json" ]; then
+  echo "ERROR: demo/auth.json not found."
+  echo "       Run: HUB_EMAIL=x HUB_PASSWORD=y node demo/login.mjs"
+  exit 1
+fi
+
+echo "Mission Control — Recording All 8 Promo Videos"
+echo "TTS Provider: $PROVIDER"
+echo "Tabs: ${#TABS[@]}"
+echo ""
+
+FAILED=()
+
+for SLUG in "${TABS[@]}"; do
+  echo "========================================"
+  echo "  TAB: $SLUG"
+  echo "========================================"
+
+  # 1. Record
+  echo "  [1/3] Recording UI …"
+  if ! node "$DEMO_DIR/record_tab.mjs" "$SLUG"; then
+    echo "  ERROR: Recording failed for $SLUG"
+    FAILED+=("$SLUG:record")
+    continue
+  fi
+
+  # 2. Voice
+  echo "  [2/3] Generating narration …"
+  if ! TTS_PROVIDER=$PROVIDER /usr/bin/python3 "$DEMO_DIR/voice.py" --tab "$SLUG"; then
+    echo "  ERROR: Voice generation failed for $SLUG"
+    FAILED+=("$SLUG:voice")
+    continue
+  fi
+
+  # 3. Merge
+  echo "  [3/3] Merging A/V …"
+  if ! bash "$DEMO_DIR/sync_tab.sh" "$SLUG"; then
+    echo "  ERROR: Merge failed for $SLUG"
+    FAILED+=("$SLUG:sync")
+    continue
+  fi
+
+  NAME="${SLUG#*_}"
+  echo "  → demo/tabs/$SLUG/${NAME}.mp4"
+  echo ""
+done
+
+echo "========================================"
+echo "DONE"
+echo ""
+
+# List all outputs
+echo "Output files:"
+for SLUG in "${TABS[@]}"; do
+  NAME="${SLUG#*_}"
+  MP4="$DEMO_DIR/tabs/$SLUG/${NAME}.mp4"
+  if [ -f "$MP4" ]; then
+    DUR=$(ffprobe -v quiet -show_entries format=duration -of "csv=p=0" "$MP4" 2>/dev/null | xargs printf "%.0fs" 2>/dev/null || echo "?")
+    echo "  ✓ $MP4 ($DUR)"
+  else
+    echo "  ✗ $MP4 (missing)"
+  fi
+done
+
+if [ ${#FAILED[@]} -gt 0 ]; then
+  echo ""
+  echo "FAILED: ${FAILED[*]}"
+  exit 1
+fi

--- a/apps/mission-control/demo/script.md
+++ b/apps/mission-control/demo/script.md
@@ -1,0 +1,101 @@
+# Mission Control — Full Feature Walkthrough Script
+
+Format: `[HH:MM:SS] [ACTION] Narration text`
+Duration per segment = next timestamp minus current timestamp.
+
+Actions:
+- `NAV:/route` — navigate to route
+- `CLICK:selector` — click element matching selector
+- `FILL:selector:value` — type into input
+- `HOVER:selector` — hover over element
+- `SCROLL:+N` — scroll down N pixels
+- `SCROLL:-N` — scroll up N pixels
+- `PAUSE` — no UI interaction, just hold
+
+---
+
+[00:00:00] [PAUSE] Welcome to Mission Control — FactoryLM's central command interface for your industrial automation cluster. Here's everything it can do.
+
+[00:00:10] [NAV:/] Chat Relay is the core of Mission Control. It routes natural language prompts directly to Claude Code running on any Jarvis node in your cluster.
+
+[00:00:18] [CLICK:select] This dropdown lets you target a specific machine — Alpha, Bravo, Charlie, or the VPS.
+
+[00:00:24] [CLICK:input[type="text"]] Set the working directory so Claude Code operates in the right project context.
+
+[00:00:29] [CLICK:select:nth-of-type(2)] Choose how long to wait for a response: one, three, five, or ten minutes.
+
+[00:00:34] [FILL:textarea:Tell me what tests are failing in this repo] Type your prompt in this field — exactly what you'd type into Claude Code at the terminal. Control-Enter dispatches it.
+
+[00:00:41] [PAUSE] Results appear in the message history below — expandable cards with stdout, stderr, exit code, and elapsed time.
+
+[00:00:48] [SCROLL:+300] The status indicator at the top right shows which Jarvis nodes are reachable in real time.
+
+[00:00:54] [NAV:/dashboard] The Dashboard is your live system snapshot — everything happening across the cluster on a single screen.
+
+[00:01:02] [PAUSE] Four stat cards show current workflow count, active worker pool size, agent count, and Ralph's live status.
+
+[00:01:09] [SCROLL:+400] The Human-in-the-Loop queue is where autonomous actions wait before executing. Each item is color-coded by risk — green for safe, yellow for caution, red for destructive.
+
+[00:01:19] [PAUSE] Action types include deployments, git pushes, force-pushes, deletes, PLC writes, and repo resurrections. You approve or reject each one individually.
+
+[00:01:27] [SCROLL:+400] The right column shows every Jarvis node in the cluster and its current health status.
+
+[00:01:33] [SCROLL:+300] Below that, PLC collector status — S7, Allen-Bradley, and Modbus — shows whether live industrial telemetry is flowing.
+
+[00:01:40] [SCROLL:+300] Quick Actions let you fire common shell commands with one click. Each is tagged with a risk level so you know what you're touching before you hit it.
+
+[00:01:48] [NAV:/terminal] The Terminal tab gives you a direct remote shell into any Jarvis node without leaving the browser.
+
+[00:01:55] [CLICK:select] Pick your target node from the dropdown, then set a command timeout from ten seconds to two minutes.
+
+[00:02:00] [FILL:input[placeholder*="command" i]:hostname && uptime] Results appear with stdout in green and stderr in red, plus exit code and elapsed time. Arrow keys navigate your command history just like a real terminal.
+
+[00:02:08] [SCROLL:+500] The same Quick Actions grid is here for one-click access to preset commands.
+
+[00:02:13] [NAV:/workers] Worker Swarm manages the Celery task pool that powers every autonomous operation in the cluster.
+
+[00:02:20] [SCROLL:+400] Workers are organized into eight categories: Core Operations, Knowledge, Analysis, Integration, PLC, Content, Development, and Security — twenty-five workers total.
+
+[00:02:28] [SCROLL:+400] Each card shows the worker's formatted name and live status — active, running, idle, or offline.
+
+[00:02:34] [SCROLL:+400] The plus and minus buttons grow or shrink the pool for any worker by one instance. Scale up under load, scale down to save resources.
+
+[00:02:41] [NAV:/ralph] Ralph is Mission Control's autonomous code evolution engine — it iterates on a codebase continuously, proposing and applying improvements in a loop.
+
+[00:02:48] [PAUSE] The status badge tells you whether Ralph is running, paused, stopped, or has tripped an error state.
+
+[00:02:54] [SCROLL:+300] Stats track total iterations completed, the current session identifier, and the circuit breaker state.
+
+[00:03:01] [SCROLL:+300] You can start Ralph on any project path, then pause or stop mid-loop without losing state. Pause is non-destructive — it resumes exactly where it left off.
+
+[00:03:08] [SCROLL:+300] The circuit breaker auto-halts Ralph when failure count exceeds a configured threshold. The health bar shows your current failure ratio at a glance.
+
+[00:03:16] [SCROLL:+200] The safety warning is there for a reason — Ralph makes real changes to real code. Always point it at a feature branch, not main.
+
+[00:03:23] [NAV:/agents] The Agents tab manages the four high-level autonomous agents that coordinate the entire worker layer.
+
+[00:03:29] [PAUSE] Ralph handles code evolution. Cosmos runs the video production pipeline. MediaOffload handles media archival and compression. And Jesus H Christ is the repo resurrection specialist. Each agent can be started or stopped independently.
+
+[00:03:39] [NAV:/tools] The Tools tab is where the monetized services live — starting with Jesus H Christ, Repo Resurrection.
+
+[00:03:45] [PAUSE] JHC takes dead or abandoned GitHub repositories and brings them back to life — updated dependencies, repaired CI, and a working test suite.
+
+[00:03:53] [FILL:input[placeholder*="GitHub org" i]:mikecranesync] Enter a GitHub org to scan for resurrection candidates. The engine scores each repo by how far it has decayed.
+
+[00:04:00] [SCROLL:+300] To resurrect a specific repo, paste the URL and choose your aggression level.
+
+[00:04:06] [CLICK:select] Gentle is documentation-only work at ninety-nine dollars. Moderate handles dependencies and CI at two-ninety-nine. Full aggressive refactor — the complete overhaul — is nine-ninety-nine.
+
+[00:04:16] [SCROLL:+200] These checkboxes let you fine-tune what JHC is allowed to touch — dependency upgrades and CI configuration are controlled separately.
+
+[00:04:22] [SCROLL:+200] Every resurrection queues an approval action in the HIL queue first. Nothing touches your codebase until you say so.
+
+[00:04:29] [SCROLL:+500] Git Forensics runs static analysis on any local repository — full history reports and hotspot detection to find which files change most and why.
+
+[00:04:37] [NAV:/hub] Finally, the Ladder Logic tab embeds a live reference view of the Micro 820 PLC's control program.
+
+[00:04:44] [PAUSE] This is a direct window into the PLC logic — rungs, coils, and contacts — running live alongside your factory hardware.
+
+[00:04:51] [NAV:/] That's Mission Control — eight tabs, forty-plus autonomous capabilities, one unified command surface for the entire FactoryLM cluster.
+
+[00:04:59] [END]

--- a/apps/mission-control/demo/sync.sh
+++ b/apps/mission-control/demo/sync.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Mission Control Demo — A/V Sync
+#
+# Merges the Playwright webm recording with the TTS narration track
+# into a final polished MP4.
+#
+# Usage (from repo root):
+#   bash apps/mission-control/demo/sync.sh
+#
+# Prerequisites:
+#   ffmpeg installed (brew install ffmpeg)
+#   demo/raw/*.webm  — produced by record.mjs
+#   demo/audio/full_narration.mp3 — produced by voice.py
+
+set -euo pipefail
+
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+RAW_DIR="$DEMO_DIR/raw"
+AUDIO_FILE="$DEMO_DIR/audio/full_narration.mp3"
+OUT_FILE="$DEMO_DIR/final_demo.mp4"
+
+# --- Validate inputs ---
+
+if [ ! -d "$RAW_DIR" ] || [ -z "$(ls -A "$RAW_DIR"/*.webm 2>/dev/null)" ]; then
+  echo "ERROR: No webm files found in $RAW_DIR"
+  echo "       Run: node apps/mission-control/demo/record.mjs"
+  exit 1
+fi
+
+if [ ! -f "$AUDIO_FILE" ]; then
+  echo "ERROR: Audio not found: $AUDIO_FILE"
+  echo "       Run: TTS_PROVIDER=macos python apps/mission-control/demo/voice.py"
+  exit 1
+fi
+
+# Pick the most recently modified webm (Playwright names them by context ID)
+LATEST_WEBM=$(ls -t "$RAW_DIR"/*.webm | head -1)
+echo "Video : $LATEST_WEBM"
+echo "Audio : $AUDIO_FILE"
+echo "Output: $OUT_FILE"
+echo ""
+
+# --- Merge ---
+
+ffmpeg -y \
+  -i "$LATEST_WEBM" \
+  -i "$AUDIO_FILE" \
+  -c:v libx264 -preset fast -crf 18 \
+  -c:a aac -b:a 192k \
+  -shortest \
+  "$OUT_FILE"
+
+echo ""
+echo "Done → $OUT_FILE"
+
+# Print duration info
+ffprobe -v quiet -show_entries format=duration \
+  -of "csv=p=0" "$OUT_FILE" 2>/dev/null \
+  | xargs -I{} echo "Duration: {}s"

--- a/apps/mission-control/demo/sync_tab.sh
+++ b/apps/mission-control/demo/sync_tab.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Mission Control — Per-Tab A/V Merge
+#
+# Usage (from apps/mission-control/):
+#   bash demo/sync_tab.sh <slug>
+#
+# Example:
+#   bash demo/sync_tab.sh 01_chat_relay
+#   → demo/tabs/01_chat_relay/chat_relay.mp4
+
+set -euo pipefail
+
+SLUG=${1:?Usage: bash demo/sync_tab.sh <slug>}
+DEMO_DIR="$(cd "$(dirname "$0")" && pwd)"
+TAB_DIR="$DEMO_DIR/tabs/$SLUG"
+
+if [ ! -d "$TAB_DIR" ]; then
+  echo "ERROR: Tab directory not found: $TAB_DIR"
+  exit 1
+fi
+
+AUDIO_FILE="$TAB_DIR/audio/full_narration.mp3"
+if [ ! -f "$AUDIO_FILE" ]; then
+  echo "ERROR: Audio not found: $AUDIO_FILE"
+  echo "       Run: TTS_PROVIDER=macos python demo/voice.py --tab $SLUG"
+  exit 1
+fi
+
+# Pick most recent webm in tab's raw/ dir
+WEBM=$(ls -t "$TAB_DIR/raw/"*.webm 2>/dev/null | head -1)
+if [ -z "$WEBM" ]; then
+  echo "ERROR: No webm found in $TAB_DIR/raw/"
+  echo "       Run: node demo/record_tab.mjs $SLUG"
+  exit 1
+fi
+
+# Output filename: strip the NN_ prefix (e.g. 01_chat_relay → chat_relay.mp4)
+NAME="${SLUG#*_}"
+OUT="$TAB_DIR/${NAME}.mp4"
+
+echo "Video : $WEBM"
+echo "Audio : $AUDIO_FILE"
+echo "Output: $OUT"
+
+ffmpeg -y \
+  -i "$WEBM" \
+  -i "$AUDIO_FILE" \
+  -c:v libx264 -preset fast -crf 18 \
+  -c:a aac -b:a 192k \
+  -shortest \
+  "$OUT"
+
+echo ""
+echo "Done → $OUT"
+ffprobe -v quiet -show_entries format=duration -of "csv=p=0" "$OUT" 2>/dev/null \
+  | xargs -I{} printf "Duration: %.1fs\n" {}

--- a/apps/mission-control/demo/tabs/01_chat_relay/script.md
+++ b/apps/mission-control/demo/tabs/01_chat_relay/script.md
@@ -1,0 +1,19 @@
+# Chat Relay — Promo Script (~60s)
+
+[00:00:00] [PAUSE] Chat Relay puts every Claude Code node in your cluster at your fingertips — one browser tab, any machine, any project, from anywhere in the world.
+
+[00:00:08] [CLICK:select] This dropdown lists every Jarvis node in your cluster — Alpha, Bravo, Charlie, or the cloud VPS. Pick one and every prompt routes directly to that machine.
+
+[00:00:15] [CLICK:input[type="text"]] Set the project path so Claude Code opens in the right context — any directory on that machine, wherever you need it.
+
+[00:00:21] [CLICK:select] Set a timeout that matches the work — one minute for quick questions, up to ten for deep refactors.
+
+[00:00:27] [FILL:textarea:Find all failing tests and explain why each one fails] Type any prompt you would normally write at the terminal. Control-Enter dispatches it to the selected node.
+
+[00:00:35] [PAUSE] Results come back as expandable message cards — stdout, stderr, exit code, and elapsed time all visible at a glance.
+
+[00:00:43] [SCROLL:+300] The node status indicators show live cluster health in real time — green means that machine is reachable and ready right now.
+
+[00:00:50] [PAUSE] No SSH client, no VPN, no terminal emulator — just your browser and the full power of Claude Code running on your own hardware.
+
+[00:01:00] [END]

--- a/apps/mission-control/demo/tabs/01_chat_relay/timecodes.json
+++ b/apps/mission-control/demo/tabs/01_chat_relay/timecodes.json
@@ -1,0 +1,37 @@
+[
+  {
+    "t": 0,
+    "duration_s": 8,
+    "narration": "Chat Relay puts every Claude Code node in your cluster at your fingertips — one browser tab, any machine, any project, from anywhere in the world."
+  },
+  {
+    "t": 8,
+    "duration_s": 13,
+    "narration": "This dropdown lists every Jarvis node in your cluster — Alpha, Bravo, Charlie, or the cloud VPS. Pick one and every prompt routes directly to that machine."
+  },
+  {
+    "t": 21,
+    "duration_s": 6,
+    "narration": "Set a timeout that matches the work — one minute for quick questions, up to ten for deep refactors."
+  },
+  {
+    "t": 27,
+    "duration_s": 8,
+    "narration": "Type any prompt you would normally write at the terminal. Control-Enter dispatches it to the selected node."
+  },
+  {
+    "t": 35,
+    "duration_s": 8,
+    "narration": "Results come back as expandable message cards — stdout, stderr, exit code, and elapsed time all visible at a glance."
+  },
+  {
+    "t": 43,
+    "duration_s": 7,
+    "narration": "The node status indicators show live cluster health in real time — green means that machine is reachable and ready right now."
+  },
+  {
+    "t": 50,
+    "duration_s": 0,
+    "narration": "No SSH client, no VPN, no terminal emulator — just your browser and the full power of Claude Code running on your own hardware."
+  }
+]

--- a/apps/mission-control/demo/tabs/02_dashboard/script.md
+++ b/apps/mission-control/demo/tabs/02_dashboard/script.md
@@ -1,0 +1,21 @@
+# Dashboard — Promo Script (~75s)
+
+[00:00:00] [PAUSE] The Dashboard gives you complete operational awareness across your entire FactoryLM cluster — every workflow, every worker, every pending decision, on one screen.
+
+[00:00:09] [PAUSE] Four stat cards at the top show live counts: active workflows, running workers, deployed agents, and Ralph's current status.
+
+[00:00:17] [SCROLL:+350] The Human-in-the-Loop queue is where autonomous actions pause for your approval before executing. Each action is color-coded by risk — green for safe operations, yellow for caution, red for destructive changes.
+
+[00:00:28] [PAUSE] Action types include deployments, git pushes, force-pushes, file deletes, PLC register writes, and repo resurrections. Nothing runs without your sign-off.
+
+[00:00:37] [CLICK:button:has-text("Approve")] Approve or reject each action individually. Rejected actions are logged and discarded; approved actions execute immediately.
+
+[00:00:44] [SCROLL:+350] The Node Status panel on the right shows every Jarvis machine in the cluster — hostname, port, and live online or offline status.
+
+[00:00:52] [SCROLL:+250] PLC Collector status tells you whether industrial telemetry is flowing from your Siemens S7, Allen-Bradley, or Modbus devices.
+
+[00:01:00] [SCROLL:+250] Quick Actions let you fire common shell commands across the cluster with one click — each tagged with a risk level so you know what you're about to run.
+
+[00:01:08] [PAUSE] One screen, total control, zero surprises.
+
+[00:01:15] [END]

--- a/apps/mission-control/demo/tabs/02_dashboard/timecodes.json
+++ b/apps/mission-control/demo/tabs/02_dashboard/timecodes.json
@@ -1,0 +1,47 @@
+[
+  {
+    "t": 0,
+    "duration_s": 9,
+    "narration": "The Dashboard gives you complete operational awareness across your entire FactoryLM cluster — every workflow, every worker, every pending decision, on one screen."
+  },
+  {
+    "t": 9,
+    "duration_s": 8,
+    "narration": "Four stat cards at the top show live counts: active workflows, running workers, deployed agents, and Ralph's current status."
+  },
+  {
+    "t": 17,
+    "duration_s": 11,
+    "narration": "The Human-in-the-Loop queue is where autonomous actions pause for your approval before executing. Each action is color-coded by risk — green for safe operations, yellow for caution, red for destructive changes."
+  },
+  {
+    "t": 28,
+    "duration_s": 9,
+    "narration": "Action types include deployments, git pushes, force-pushes, file deletes, PLC register writes, and repo resurrections. Nothing runs without your sign-off."
+  },
+  {
+    "t": 37,
+    "duration_s": 7,
+    "narration": "Approve or reject each action individually. Rejected actions are logged and discarded; approved actions execute immediately."
+  },
+  {
+    "t": 44,
+    "duration_s": 8,
+    "narration": "The Node Status panel on the right shows every Jarvis machine in the cluster — hostname, port, and live online or offline status."
+  },
+  {
+    "t": 52,
+    "duration_s": 8,
+    "narration": "PLC Collector status tells you whether industrial telemetry is flowing from your Siemens S7, Allen-Bradley, or Modbus devices."
+  },
+  {
+    "t": 60,
+    "duration_s": 8,
+    "narration": "Quick Actions let you fire common shell commands across the cluster with one click — each tagged with a risk level so you know what you're about to run."
+  },
+  {
+    "t": 68,
+    "duration_s": 0,
+    "narration": "One screen, total control, zero surprises."
+  }
+]

--- a/apps/mission-control/demo/tabs/03_terminal/script.md
+++ b/apps/mission-control/demo/tabs/03_terminal/script.md
@@ -1,0 +1,15 @@
+# Terminal — Promo Script (~45s)
+
+[00:00:00] [PAUSE] The Terminal tab gives you a browser-native remote shell into any Jarvis node in your cluster — no SSH client, no VPN, no configuration.
+
+[00:00:09] [CLICK:select] Pick the target node from the dropdown — each machine in your cluster is listed and ready.
+
+[00:00:15] [FILL:input[placeholder*="command" i]:df -h && free -m && uptime] Type any shell command. Results come back with stdout in green, stderr in red, plus exit code and elapsed time.
+
+[00:00:23] [PAUSE] Arrow keys navigate your command history just like a real terminal — your last fifty commands are always a keystroke away.
+
+[00:00:30] [SCROLL:+450] The Quick Actions panel below gives you one-click access to common operations — system checks, service restarts, log tails — each rated by risk level before you run it.
+
+[00:00:39] [PAUSE] Full remote shell access, right in your browser, on every machine in your cluster.
+
+[00:00:45] [END]

--- a/apps/mission-control/demo/tabs/04_worker_swarm/script.md
+++ b/apps/mission-control/demo/tabs/04_worker_swarm/script.md
@@ -1,0 +1,13 @@
+# Worker Swarm — Promo Script (~50s)
+
+[00:00:00] [PAUSE] Worker Swarm is the engine room of FactoryLM — twenty-five autonomous Celery workers organized into eight functional domains, all managed from one screen.
+
+[00:00:10] [SCROLL:+300] Workers span Core Operations, Knowledge ingestion, Analysis, Integration, PLC data collection, Content production, Development, and Security — every autonomous capability in the cluster, visible at a glance.
+
+[00:00:22] [PAUSE] Each worker card shows its formatted name and live status: active, running, idle, or offline. No guessing what's happening in the background.
+
+[00:00:31] [SCROLL:+400] The plus and minus buttons grow or shrink any worker's pool by one instance. Spike in demand? Scale up instantly. Quiet period? Scale back down.
+
+[00:00:40] [PAUSE] Twenty-five workers, eight domains, infinite leverage.
+
+[00:00:45] [END]

--- a/apps/mission-control/demo/tabs/05_ralph_loop/script.md
+++ b/apps/mission-control/demo/tabs/05_ralph_loop/script.md
@@ -1,0 +1,15 @@
+# Ralph Loop — Promo Script (~55s)
+
+[00:00:00] [PAUSE] Ralph is Mission Control's autonomous code evolution engine. Point it at a project and it iterates continuously — analyzing, proposing, and applying improvements while you focus on other things.
+
+[00:00:11] [PAUSE] The status badge tells you exactly where Ralph is at any moment: running, paused, stopped, or in an error state. No ambiguity.
+
+[00:00:19] [SCROLL:+300] The stats grid tracks total iterations completed, the current session identifier, and the circuit breaker state — your safety net against runaway loops.
+
+[00:00:28] [SCROLL:+300] Start Ralph on any project path. When you need to intervene, pause mid-loop without losing state. Resume exactly where it left off. Stop cleanly when the work is done.
+
+[00:00:38] [SCROLL:+250] The circuit breaker monitors failure rate in real time. If something goes wrong repeatedly, it opens automatically and halts execution before any real damage is done.
+
+[00:00:47] [SCROLL:+200] The safety warning is not decoration — Ralph modifies real code. Use feature branches, review the HIL queue, and stay in control of what ships.
+
+[00:00:55] [END]

--- a/apps/mission-control/demo/tabs/06_agents/script.md
+++ b/apps/mission-control/demo/tabs/06_agents/script.md
@@ -1,0 +1,11 @@
+# Agents — Promo Script (~40s)
+
+[00:00:00] [PAUSE] The Agents tab gives you lifecycle control over the four high-level autonomous agents that coordinate everything in the cluster.
+
+[00:00:08] [PAUSE] Ralph handles continuous code evolution. Cosmos manages the video production pipeline. MediaOffload handles archival and compression. Jesus H Christ resurrects abandoned repositories.
+
+[00:00:19] [PAUSE] Each agent card shows its current status — running, starting, stopping, stopped, or on-demand — along with a description and its type and location in the cluster.
+
+[00:00:29] [PAUSE] Start or stop any agent independently with a single button. Status updates live so you always know exactly what's running.
+
+[00:00:37] [END]

--- a/apps/mission-control/demo/tabs/07_tools/script.md
+++ b/apps/mission-control/demo/tabs/07_tools/script.md
@@ -1,0 +1,21 @@
+# Tools — Promo Script (~80s)
+
+[00:00:00] [PAUSE] The Tools tab is where FactoryLM's commercial services live — starting with Jesus H Christ, the repo resurrection service.
+
+[00:00:09] [PAUSE] JHC takes dead or abandoned GitHub repositories and brings them back to production-ready condition — updated dependencies, repaired CI pipelines, and a working test suite.
+
+[00:00:20] [FILL:input[placeholder*="GitHub org" i]:mikecranesync] Scan any GitHub organization to find resurrection candidates. The engine scores every repo by how far it has decayed and ranks them for you.
+
+[00:00:30] [SCROLL:+300] To start a resurrection, paste the repository URL and choose your aggression level.
+
+[00:00:37] [CLICK:select] Gentle is documentation-only work — ninety-nine dollars. Moderate handles dependency upgrades and CI repairs — two-ninety-nine. Aggressive is the full refactor — updated codebase, tests, CI, docs — nine-ninety-nine.
+
+[00:00:50] [SCROLL:+200] Fine-tune what JHC is allowed to touch with these permission checkboxes — dependency upgrades and CI edits are controlled separately.
+
+[00:00:58] [SCROLL:+200] Every resurrection queues an approval action in the HIL queue before touching a single file. You see exactly what will change and approve it before it runs.
+
+[00:01:06] [SCROLL:+450] Git Forensics is a free companion tool — run static analysis on any local repository to generate full history reports and identify the hotspot files that cause the most churn.
+
+[00:01:17] [PAUSE] Revive dead repos, understand your git history, and ship with confidence.
+
+[00:01:20] [END]

--- a/apps/mission-control/demo/tabs/08_hub/script.md
+++ b/apps/mission-control/demo/tabs/08_hub/script.md
@@ -1,0 +1,9 @@
+# Hub / Ladder Logic — Promo Script (~25s)
+
+[00:00:00] [PAUSE] The Ladder Logic tab embeds a live reference view of your Micro 820 PLC's control program — your factory logic, visible from the cloud.
+
+[00:00:10] [PAUSE] Every rung, coil, and contact is rendered in real time alongside your operational data. No proprietary software, no local install — just the browser.
+
+[00:00:20] [PAUSE] Factory automation intelligence, cloud-connected.
+
+[00:00:25] [END]

--- a/apps/mission-control/demo/timecodes.json
+++ b/apps/mission-control/demo/timecodes.json
@@ -1,0 +1,197 @@
+[
+  {
+    "t": 0,
+    "duration_s": 10,
+    "narration": "Welcome to Mission Control — FactoryLM's central command interface for your industrial automation cluster. Here's everything it can do."
+  },
+  {
+    "t": 10,
+    "duration_s": 8,
+    "narration": "Chat Relay is the core of Mission Control. It routes natural language prompts directly to Claude Code running on any Jarvis node in your cluster."
+  },
+  {
+    "t": 18,
+    "duration_s": 11,
+    "narration": "This dropdown lets you target a specific machine — Alpha, Bravo, Charlie, or the VPS."
+  },
+  {
+    "t": 29,
+    "duration_s": 5,
+    "narration": "Choose how long to wait for a response: one, three, five, or ten minutes."
+  },
+  {
+    "t": 34,
+    "duration_s": 7,
+    "narration": "Type your prompt in this field — exactly what you'd type into Claude Code at the terminal. Control-Enter dispatches it."
+  },
+  {
+    "t": 41,
+    "duration_s": 7,
+    "narration": "Results appear in the message history below — expandable cards with stdout, stderr, exit code, and elapsed time."
+  },
+  {
+    "t": 48,
+    "duration_s": 6,
+    "narration": "The status indicator at the top right shows which Jarvis nodes are reachable in real time."
+  },
+  {
+    "t": 54,
+    "duration_s": 8,
+    "narration": "The Dashboard is your live system snapshot — everything happening across the cluster on a single screen."
+  },
+  {
+    "t": 62,
+    "duration_s": 7,
+    "narration": "Four stat cards show current workflow count, active worker pool size, agent count, and Ralph's live status."
+  },
+  {
+    "t": 69,
+    "duration_s": 10,
+    "narration": "The Human-in-the-Loop queue is where autonomous actions wait before executing. Each item is color-coded by risk — green for safe, yellow for caution, red for destructive."
+  },
+  {
+    "t": 79,
+    "duration_s": 8,
+    "narration": "Action types include deployments, git pushes, force-pushes, deletes, PLC writes, and repo resurrections. You approve or reject each one individually."
+  },
+  {
+    "t": 87,
+    "duration_s": 6,
+    "narration": "The right column shows every Jarvis node in the cluster and its current health status."
+  },
+  {
+    "t": 93,
+    "duration_s": 7,
+    "narration": "Below that, PLC collector status — S7, Allen-Bradley, and Modbus — shows whether live industrial telemetry is flowing."
+  },
+  {
+    "t": 100,
+    "duration_s": 8,
+    "narration": "Quick Actions let you fire common shell commands with one click. Each is tagged with a risk level so you know what you're touching before you hit it."
+  },
+  {
+    "t": 108,
+    "duration_s": 7,
+    "narration": "The Terminal tab gives you a direct remote shell into any Jarvis node without leaving the browser."
+  },
+  {
+    "t": 115,
+    "duration_s": 13,
+    "narration": "Pick your target node from the dropdown, then set a command timeout from ten seconds to two minutes."
+  },
+  {
+    "t": 128,
+    "duration_s": 5,
+    "narration": "The same Quick Actions grid is here for one-click access to preset commands."
+  },
+  {
+    "t": 133,
+    "duration_s": 7,
+    "narration": "Worker Swarm manages the Celery task pool that powers every autonomous operation in the cluster."
+  },
+  {
+    "t": 140,
+    "duration_s": 8,
+    "narration": "Workers are organized into eight categories: Core Operations, Knowledge, Analysis, Integration, PLC, Content, Development, and Security — twenty-five workers total."
+  },
+  {
+    "t": 148,
+    "duration_s": 6,
+    "narration": "Each card shows the worker's formatted name and live status — active, running, idle, or offline."
+  },
+  {
+    "t": 154,
+    "duration_s": 7,
+    "narration": "The plus and minus buttons grow or shrink the pool for any worker by one instance. Scale up under load, scale down to save resources."
+  },
+  {
+    "t": 161,
+    "duration_s": 7,
+    "narration": "Ralph is Mission Control's autonomous code evolution engine — it iterates on a codebase continuously, proposing and applying improvements in a loop."
+  },
+  {
+    "t": 168,
+    "duration_s": 6,
+    "narration": "The status badge tells you whether Ralph is running, paused, stopped, or has tripped an error state."
+  },
+  {
+    "t": 174,
+    "duration_s": 7,
+    "narration": "Stats track total iterations completed, the current session identifier, and the circuit breaker state."
+  },
+  {
+    "t": 181,
+    "duration_s": 7,
+    "narration": "You can start Ralph on any project path, then pause or stop mid-loop without losing state. Pause is non-destructive — it resumes exactly where it left off."
+  },
+  {
+    "t": 188,
+    "duration_s": 8,
+    "narration": "The circuit breaker auto-halts Ralph when failure count exceeds a configured threshold. The health bar shows your current failure ratio at a glance."
+  },
+  {
+    "t": 196,
+    "duration_s": 7,
+    "narration": "The safety warning is there for a reason — Ralph makes real changes to real code. Always point it at a feature branch, not main."
+  },
+  {
+    "t": 203,
+    "duration_s": 6,
+    "narration": "The Agents tab manages the four high-level autonomous agents that coordinate the entire worker layer."
+  },
+  {
+    "t": 209,
+    "duration_s": 10,
+    "narration": "Ralph handles code evolution. Cosmos runs the video production pipeline. MediaOffload handles media archival and compression. And Jesus H Christ is the repo resurrection specialist. Each agent can be started or stopped independently."
+  },
+  {
+    "t": 219,
+    "duration_s": 6,
+    "narration": "The Tools tab is where the monetized services live — starting with Jesus H Christ, Repo Resurrection."
+  },
+  {
+    "t": 225,
+    "duration_s": 15,
+    "narration": "JHC takes dead or abandoned GitHub repositories and brings them back to life — updated dependencies, repaired CI, and a working test suite."
+  },
+  {
+    "t": 240,
+    "duration_s": 6,
+    "narration": "To resurrect a specific repo, paste the URL and choose your aggression level."
+  },
+  {
+    "t": 246,
+    "duration_s": 10,
+    "narration": "Gentle is documentation-only work at ninety-nine dollars. Moderate handles dependencies and CI at two-ninety-nine. Full aggressive refactor — the complete overhaul — is nine-ninety-nine."
+  },
+  {
+    "t": 256,
+    "duration_s": 6,
+    "narration": "These checkboxes let you fine-tune what JHC is allowed to touch — dependency upgrades and CI configuration are controlled separately."
+  },
+  {
+    "t": 262,
+    "duration_s": 7,
+    "narration": "Every resurrection queues an approval action in the HIL queue first. Nothing touches your codebase until you say so."
+  },
+  {
+    "t": 269,
+    "duration_s": 8,
+    "narration": "Git Forensics runs static analysis on any local repository — full history reports and hotspot detection to find which files change most and why."
+  },
+  {
+    "t": 277,
+    "duration_s": 7,
+    "narration": "Finally, the Ladder Logic tab embeds a live reference view of the Micro 820 PLC's control program."
+  },
+  {
+    "t": 284,
+    "duration_s": 7,
+    "narration": "This is a direct window into the PLC logic — rungs, coils, and contacts — running live alongside your factory hardware."
+  },
+  {
+    "t": 291,
+    "duration_s": 0,
+    "narration": "That's Mission Control — eight tabs, forty-plus autonomous capabilities, one unified command surface for the entire FactoryLM cluster."
+  }
+]

--- a/apps/mission-control/demo/voice.py
+++ b/apps/mission-control/demo/voice.py
@@ -1,0 +1,229 @@
+"""
+Mission Control Demo — Voice Generator
+
+Reads a script.md, extracts narration text per segment,
+generates per-segment audio files, and concatenates into full_narration.mp3.
+
+Usage:
+    # Full walkthrough (legacy):
+    TTS_PROVIDER=macos python demo/voice.py
+
+    # Single tab promo:
+    TTS_PROVIDER=macos python demo/voice.py --tab 01_chat_relay
+
+Env vars:
+    TTS_PROVIDER          elevenlabs | openai | macos  (default: macos)
+    ELEVENLABS_API_KEY    required for elevenlabs
+    OPENAI_API_KEY        required for openai
+    ELEVENLABS_VOICE_ID   optional (default: Rachel)
+"""
+
+import argparse
+import os
+import re
+import sys
+import subprocess
+import json
+from pathlib import Path
+
+DEMO_DIR = Path(__file__).parent
+SCRIPT_PATH = DEMO_DIR / "script.md"
+AUDIO_DIR = DEMO_DIR / "audio"
+TIMECODES_PATH = DEMO_DIR / "timecodes.json"
+
+AUDIO_DIR.mkdir(exist_ok=True)
+
+PROVIDER = os.environ.get("TTS_PROVIDER", "macos").lower()
+
+
+# ---------------------------------------------------------------------------
+# Script parser
+# ---------------------------------------------------------------------------
+
+def parse_segments(path):
+    """Return list of {t, narration} dicts from script.md."""
+    segments = []
+    pattern = re.compile(r'^\[(\d{2}:\d{2}:\d{2})\]\s+\[[^\]]+\]\s+(.+)$')
+    for line in path.read_text().splitlines():
+        m = pattern.match(line)
+        if not m:
+            continue
+        ts, narration = m.group(1), m.group(2).strip()
+        if narration == "END" or "[END]" in line:
+            continue
+        h, mn, s = map(int, ts.split(":"))
+        t = h * 3600 + mn * 60 + s
+        segments.append({"ts": ts, "t": t, "narration": narration})
+    return segments
+
+
+# ---------------------------------------------------------------------------
+# TTS backends
+# ---------------------------------------------------------------------------
+
+def generate_elevenlabs(text, out_path):
+    try:
+        import requests
+    except ImportError:
+        sys.exit("Install requests: pip install requests")
+
+    api_key = os.environ.get("ELEVENLABS_API_KEY")
+    if not api_key:
+        sys.exit("Set ELEVENLABS_API_KEY env var")
+
+    voice_id = os.environ.get("ELEVENLABS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")  # Rachel
+    url = f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
+
+    resp = requests.post(
+        url,
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+        json={
+            "text": text,
+            "model_id": "eleven_monolingual_v1",
+            "voice_settings": {"stability": 0.5, "similarity_boost": 0.75},
+        },
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+    # ElevenLabs returns mp3 directly
+    out_path.with_suffix(".mp3").write_bytes(resp.content)
+    return out_path.with_suffix(".mp3")
+
+
+def generate_openai(text, out_path):
+    try:
+        from openai import OpenAI
+    except ImportError:
+        sys.exit("Install openai: pip install openai")
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        sys.exit("Set OPENAI_API_KEY env var")
+
+    client = OpenAI(api_key=api_key)
+    response = client.audio.speech.create(
+        model="tts-1-hd",
+        voice="onyx",
+        input=text,
+    )
+    mp3_path = out_path.with_suffix(".mp3")
+    response.stream_to_file(str(mp3_path))
+    return mp3_path
+
+
+def generate_macos(text, out_path):
+    """Use macOS say command — no API key required."""
+    aiff_path = out_path.with_suffix(".aiff")
+    mp3_path = out_path.with_suffix(".mp3")
+
+    subprocess.run(
+        ["say", "-v", "Samantha", "-r", "165", "-o", str(aiff_path), text],
+        check=True,
+    )
+
+    # Convert aiff → mp3 via ffmpeg
+    subprocess.run(
+        ["ffmpeg", "-y", "-i", str(aiff_path), "-q:a", "2", str(mp3_path)],
+        check=True,
+        capture_output=True,
+    )
+    aiff_path.unlink(missing_ok=True)
+    return mp3_path
+
+
+GENERATORS = {
+    "elevenlabs": generate_elevenlabs,
+    "openai": generate_openai,
+    "macos": generate_macos,
+}
+
+
+# ---------------------------------------------------------------------------
+# Concatenation
+# ---------------------------------------------------------------------------
+
+def concatenate_segments(mp3_paths, out_path):
+    """Use ffmpeg concat demuxer to join segments in order."""
+    list_path = AUDIO_DIR / "concat_list.txt"
+    list_path.write_text(
+        "\n".join(f"file '{p.resolve()}'" for p in mp3_paths)
+    )
+    subprocess.run(
+        [
+            "ffmpeg", "-y",
+            "-f", "concat", "-safe", "0",
+            "-i", str(list_path),
+            "-c", "copy",
+            str(out_path),
+        ],
+        check=True,
+    )
+    list_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Mission Control Voice Generator")
+    parser.add_argument("--tab", help="Tab slug (e.g. 01_chat_relay). Omit for full walkthrough script.")
+    args = parser.parse_args()
+
+    if args.tab:
+        script_path = DEMO_DIR / "tabs" / args.tab / "script.md"
+        audio_dir = DEMO_DIR / "tabs" / args.tab / "audio"
+    else:
+        script_path = SCRIPT_PATH
+        audio_dir = AUDIO_DIR
+
+    audio_dir.mkdir(parents=True, exist_ok=True)
+
+    if not script_path.exists():
+        sys.exit(f"Script not found: {script_path}")
+
+    if PROVIDER not in GENERATORS:
+        sys.exit(f"Unknown TTS_PROVIDER '{PROVIDER}'. Choose: {', '.join(GENERATORS)}")
+
+    generate = GENERATORS[PROVIDER]
+    segments = parse_segments(script_path)
+
+    label = args.tab or "full walkthrough"
+    print(f"\nMission Control Demo — Voice Generator")
+    print(f"Provider : {PROVIDER}")
+    print(f"Tab      : {label}")
+    print(f"Segments : {len(segments)}")
+    print(f"Output   : {audio_dir}/\n")
+
+    mp3_paths = []
+
+    for i, seg in enumerate(segments):
+        num = str(i + 1).zfill(3)
+        stem = audio_dir / f"segment_{num}"
+        mp3_path = stem.with_suffix(".mp3")
+
+        if mp3_path.exists():
+            print(f"  [{num}] SKIP (exists): {mp3_path.name}")
+            mp3_paths.append(mp3_path)
+            continue
+
+        print(f"  [{num}] {seg['ts']} — {seg['narration'][:60]}…")
+        try:
+            result = generate(seg["narration"], stem)
+            mp3_paths.append(result)
+        except Exception as e:
+            print(f"    ERROR: {e}")
+            sys.exit(1)
+
+    print(f"\nConcatenating {len(mp3_paths)} segments…")
+    full_path = audio_dir / "full_narration.mp3"
+    concatenate_segments(mp3_paths, full_path)
+
+    next_cmd = (f"bash demo/sync_tab.sh {args.tab}" if args.tab else "bash demo/sync.sh")
+    print(f"Done → {full_path}")
+    print(f"\nNext step: {next_cmd}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mission-control/package.json
+++ b/apps/mission-control/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mission-control",
+  "version": "1.0.0",
+  "description": "Read-only dev monitoring dashboard for all FactoryLM systems.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "playwright": "^1.61.1"
+  }
+}

--- a/remoteme-jarvis-node/install-node.sh
+++ b/remoteme-jarvis-node/install-node.sh
@@ -14,7 +14,11 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PORT="${JARVIS_PORT:-8765}"
 LABEL="com.factorylm.jarvis-node"
 
-echo "==> Jarvis Node installer   (repo: $DIR)"
+# Cluster node name (ALPHA/BRAVO/CHARLIE/PLC/TRAVEL/PI). First arg, else env, else
+# a cleaned short hostname. Baked into the service env so the node self-identifies.
+NODE_NAME="${1:-${JARVIS_MACHINE_NAME:-$(hostname -s 2>/dev/null || hostname)}}"
+
+echo "==> Jarvis Node installer   (repo: $DIR, node: $NODE_NAME)"
 
 # 1. Dependencies
 PY="$(command -v python3 || command -v python)"
@@ -42,6 +46,8 @@ case "$OS" in
   <key>Label</key><string>$LABEL</string>
   <key>ProgramArguments</key>
     <array><string>$DIR/run-node.sh</string></array>
+  <key>EnvironmentVariables</key>
+    <dict><key>JARVIS_MACHINE_NAME</key><string>$NODE_NAME</string></dict>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
   <key>StandardOutPath</key><string>$HOME/Library/Logs/jarvis-node.log</string>
@@ -62,9 +68,10 @@ Description=Jarvis Node (FastAPI remote-control MCP, tailnet-only)
 After=network-online.target
 
 [Service]
+Environment=JARVIS_MACHINE_NAME=$NODE_NAME
 ExecStart=$DIR/run-node.sh
 Restart=always
-RestartSec=3
+RestartSec=5
 
 [Install]
 WantedBy=default.target

--- a/services/skills/jarvis_dev.py
+++ b/services/skills/jarvis_dev.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import subprocess
 import httpx
 from pathlib import Path
@@ -29,6 +30,10 @@ from openclaw.skills.base import Skill, SkillContext
 from openclaw.types import Intent
 
 logger = logging.getLogger(__name__)
+
+# Bearer token for authed Jarvis nodes (set JARVIS_TOKEN in the env, e.g. via
+# Doppler factorylm/prd). Sent on every remote node request; nodes 401 without it.
+JARVIS_TOKEN = os.getenv("JARVIS_TOKEN", "")
 
 # Jarvis node registry
 JARVIS_NODES = {
@@ -82,11 +87,12 @@ class JarvisDevService:
         node_info = JARVIS_NODES[node]
         url = f"http://{node_info['host']}:{node_info['port']}/shell"
 
+        headers = {"Authorization": f"Bearer {JARVIS_TOKEN}"} if JARVIS_TOKEN else {}
         try:
             resp = await self.http.post(url, json={
                 "command": command,
                 "timeout": timeout
-            })
+            }, headers=headers)
             if resp.status_code == 200:
                 data = resp.json()
                 return {


### PR DESCRIPTION
## Summary

- Adds a complete 8-tab Playwright → macOS TTS → ffmpeg pipeline for recording promo videos from the live Hub at `app.factorylm.com`
- Fixes the Hub login: the "Sign in with password" accordion must be clicked before the password input renders — `login.mjs` now handles this two-step flow
- All generated media (`.mp4`, `.webm`, `.mp3`, `auth.json`) are gitignored

## Usage

```bash
# One-time login (saves demo/auth.json)
HUB_EMAIL=x HUB_PASSWORD=y node demo/login.mjs

# Record all 8 videos
TTS_PROVIDER=macos bash demo/run_all.sh

# Redo a single tab
node demo/record_tab.mjs 02_dashboard
TTS_PROVIDER=macos python demo/voice.py --tab 02_dashboard
bash demo/sync_tab.sh 02_dashboard
```

## Files

| File | Purpose |
|------|---------|
| `demo/login.mjs` | One-time Hub login → `auth.json` |
| `demo/record_tab.mjs` | Playwright recorder per tab |
| `demo/voice.py` | macOS/ElevenLabs/OpenAI TTS with `--tab` arg |
| `demo/sync_tab.sh` | ffmpeg A/V merge per tab |
| `demo/run_all.sh` | Orchestrates all 8 tabs |
| `demo/tabs/0N_*/script.md` | 8 promo scripts with timecodes |
| `apps/mission-control/.gitignore` | Excludes auth, raw, audio, mp4 |
| `apps/mission-control/package.json` | Playwright dep |

## Test plan

- [ ] `node demo/login.mjs` → `demo/auth.json` exists, contains cookies
- [ ] `node demo/record_tab.mjs 01_chat_relay` → `demo/tabs/01_chat_relay/raw/*.webm` recorded
- [ ] `TTS_PROVIDER=macos python demo/voice.py --tab 01_chat_relay` → `audio/full_narration.mp3`
- [ ] `bash demo/sync_tab.sh 01_chat_relay` → `chat_relay.mp4` exists, plays with voice
- [ ] `bash demo/run_all.sh` → 8 MP4s in `demo/tabs/*/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017dDHiiBj9pGgENWREJ4QHh