### PR TITLE
ops: CV-200 remote-commissioning session record (TRC-2026-06-29-001)

### DIFF
--- a/docs/ops/traces/2026-06-29-cv200-remote-commissioning-ship.md
+++ b/docs/ops/traces/2026-06-29-cv200-remote-commissioning-ship.md
@@ -1,0 +1,65 @@
+# TRC-2026-06-29-001: CV-200 Remote-Commissioning Stack Shipped + Session Record Re-homed
+
+| Field | Value |
+|-------|-------|
+| **ID** | TRC-2026-06-29-001 |
+| **Date** | 2026-06-29 |
+| **Author** | Claude (CHARLIE node) |
+| **Duration** | ~1h |
+| **Type** | feature-build / ops |
+| **Services** | MIRA command-center, MIRA cloud-wiring (Perspective + Ask-MIRA), Northwind tenant seed |
+| **Devices** | CHARLIE (192.168.1.12) |
+| **Trigger** | Ship the CV-200 (Discharge Conveyor) remote-commissioning stack and complete the session shutdown protocol |
+
+---
+
+## Context
+
+The CV-200 remote-commissioning work spanned four PRs against `Mikecranesync/MIRA`. Three were already merged at session start; the docs runbook PR (#2371) was open, green, but `mergeStateStatus: BEHIND` by one commit. Shutdown protocol (CLUSTER.md, Law 5) also required a session record to be committed — but the referenced `FactoryLM-Architecture` repo does not exist, and the SMB `betterclaw/` store it points at is unversioned. This trace re-homes the session record to its correct, version-controlled location.
+
+## What Happened
+
+1. **Verified PR state** — `gh pr view 2371` / `gh pr checks 2371`: OPEN, MERGEABLE, all 3 checks pass (Hub E2E, Version Bump Check, staging-gate), BEHIND by exactly 1 commit (`b431c878 chore(graphify): auto-refresh code graph @ 0e17684e` — the auto-graphify refresh that fired after #2370 merged).
+2. **`gh pr update-branch 2371`** — new head; required checks re-triggered.
+3. **`gh pr merge 2371 --squash --auto --delete-branch`** — armed auto-merge; all 3 checks passed; squash-merged at 20:28 UTC. No `--admin` bypass needed.
+4. **Session summary posted to Slack** — FactoryLM workspace `#all-factorylm` via a new incoming webhook (bot token lacks read scopes; webhook saved to Doppler as `SLACK_ALL_FACTORYLM_WEBHOOK`).
+5. **Repo investigation** — confirmed `FactoryLM-Architecture` is a phantom (no GitHub repo, no local dir); the real architecture repo is `Mikecranesync/factorylm`. Found `docs/ops/traces/` as the canonical, versioned home for session records. ALPHA (192.168.1.10) was unreachable (ping/SSH timeout, no SMB mount), so this record is landed from CHARLIE per the mirror-on-CHARLIE fallback.
+
+## Changes Made
+
+| File/Config | Before | After | Why |
+|-------------|--------|-------|-----|
+| MIRA `main` | 3 of 4 CV-200 PRs merged | all 4 merged (#2362, #2365, #2370, #2371) | Ship the remote-commissioning stack |
+| Doppler `factorylm/dev` `SLACK_ALL_FACTORYLM_WEBHOOK` | (absent) | incoming webhook URL → #all-factorylm | Enable cluster status posts to Slack |
+| `docs/ops/traces/2026-06-29-...md` | (absent) | this trace | Version-control the session record in its correct home |
+
+## Outcome
+
+CV-200 remote-commissioning stack fully shipped — all four PRs in `main`:
+
+| PR | Merge SHA | Summary |
+|----|-----------|---------|
+| #2362 | `6652b09e` | seed: live CV-200 on Northwind bottling tenant |
+| #2365 | `641421f1` | command-center: read-only remote-commissioning status view (PR-1) |
+| #2370 | `0e17684e` | cloud-wiring: CV-200 Perspective + Ask-MIRA (clean re-land of #2367) |
+| #2371 | `6ec778e7` | runbook: CV-200 live proof + Ignition Connector v0 packaging plan |
+
+Foreign working-tree WIP (another session's demo-pipeline changes) was left untouched per session-discipline. Session record now lives in version control instead of the unversioned SMB share.
+
+## Queryable Tags
+
+- **root-cause**: n/a (clean ship); merge was blocked only by a stale auto-graphify commit
+- **config-keys**: SLACK_ALL_FACTORYLM_WEBHOOK
+- **ports**: n/a
+- **dependencies**: gh CLI, Doppler (project `factorylm`, config `dev`)
+- **repos**: Mikecranesync/MIRA, Mikecranesync/factorylm
+
+## Open Follow-ups
+
+- **`CLUSTER.md` shutdown step references a non-existent `FactoryLM-Architecture` repo.** Recommend updating it to point session records at `factorylm` `docs/ops/traces/` and the lesson-log path accordingly.
+- **The SMB `betterclaw/` brain (logs/memory/rules) remains unversioned** and may diverge per node. Decide on a durable version-control home (separate brain repo owned by ALPHA, or fold the relevant records into `docs/ops/`).
+
+## Related
+
+- **Commits**: MIRA `6652b09e`, `641421f1`, `0e17684e`, `6ec778e7`
+- **Prior Traces**: [TRC-2026-03-01-001](./2026-03-01_charlie-node-online.md)


### PR DESCRIPTION
## What

Lands the session shutdown record for the CV-200 remote-commissioning ship into its **versioned home** — `docs/ops/traces/` — following the existing `TRC-YYYY-MM-DD-NNN` convention.

## Why

The `CLUSTER.md` shutdown protocol says to commit the session record to a `FactoryLM-Architecture` repo, but **that repo does not exist** (no GitHub repo, no local dir). The fallback path it implies — the SMB `betterclaw/` store — is **unversioned and unbacked**. This PR puts the record where the repo already keeps ops traces, so it's actually under version control and pushed.

## Contents

Single file: `docs/ops/traces/2026-06-29-cv200-remote-commissioning-ship.md`. Records the four merged MIRA CV-200 PRs (#2362, #2365, #2370, #2371) with merge SHAs and the merge/Slack steps taken.

## Follow-ups flagged in the trace (not in this PR)

- `CLUSTER.md` references a non-existent `FactoryLM-Architecture` repo — should point at this repo's `docs/ops/traces/`.
- The SMB `betterclaw/` cluster-brain (logs/memory/rules) is unversioned and may diverge per node — needs a durable VC home decision.

Note: `docs/ops/traces/` is caught by a broad `traces/` rule in `.gitignore:84`; this file was force-added to match its 22 already-tracked peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)