### PR TITLE
fix(plc-modbus): RegisterData drops every named VFD register — match REGISTER_NAMES (#161)

### DIFF
--- a/services/plc-modbus/CLAUDE.md
+++ b/services/plc-modbus/CLAUDE.md
@@ -41,7 +41,11 @@ LLM-controlled industrial automation using Allen-Bradley Micro 820 PLC with Fact
 | Address | Variable | Description |
 |---------|----------|-------------|
 | **100** | ItemCount | Items that reached SensorEnd |
-| 101-105 | (unused) | Available registers |
+| **101** | ConveyorHz | Conveyor VFD frequency, Hz |
+| **102** | MotorCurrentX10 | Motor current x10, amps = value / 10 |
+| **103** | MotorTempX10 | Motor temperature x10, degC = value / 10 |
+| **104** | VFDStatus | VFD status: 0 idle, 1 running, 2 fault |
+| **105** | ErrorCode | Active error code |
 
 ## Physical Control State Tables
 
@@ -106,4 +110,5 @@ curl -X POST http://100.72.2.99:8001/api/plc/write-coil -H "Content-Type: applic
 - **2026-01-24:** Initial integration complete. PLC recovered, Modbus working.
 - **2026-01-25:** FastAPI backend with network scanner. Systematic I/O mapping completed. Real-time monitor and logger tools created. White paper documented.
 - **2026-01-25 (PM):** Added ST case study (Appendix C) and Raspberry Pi edge device (Appendix D) to whitepaper. Created factorylm-edge directory with Modbus TCP server code for Pi.
-- **2026-02-18:** "From A to B" Factory I/O scene integration. Remapped coils 0-4 for scene (Conveyor, Emitter, SensorStart, SensorEnd, RunCommand). Register 100 = ItemCount. Backend port → 8001. ST program + CCW setup docs in `scenes/`.
+- **2026-02-18:** "From A to B" Factory I/O scene integration. Remapped coils 0-4 for scene (Conveyor, Emitter, SensorStart, SensorEnd, RunCommand). Register 100 = ItemCount (registers 101-105 later carry named VFD telemetry — see register table). Backend port → 8001. ST program + CCW setup docs in `scenes/`.
+- **2026-08-02:** #161 repair — `RegisterData` model now matches `REGISTER_NAMES` (named VFD fields ConveyorHz/MotorCurrentX10/MotorTempX10/VFDStatus/ErrorCode survive serialization); register table above updated to document 101-105.

--- a/services/plc-modbus/backend/models/plc_models.py
+++ b/services/plc-modbus/backend/models/plc_models.py
@@ -63,14 +63,22 @@ class OutputData(BaseModel):
 
 
 class RegisterData(BaseModel):
-    """Holding registers (100-105)."""
+    """Holding registers (100-105).
+
+    Field names MUST match PLCConnection.REGISTER_NAMES (plc_connection.py) —
+    read_io() builds its dict from those names, and Pydantic v2 silently DROPS
+    unknown fields. The placeholder names register_101..105 that used to live
+    here stripped every named VFD value from /api/plc/io and replaced it with
+    the 0 default, so diagnosis read zeros while the PLC reported real data
+    (issue #161). tests/unit/test_backend_models.py pins the parity.
+    """
 
     ItemCount: int = 0
-    register_101: int = 0
-    register_102: int = 0
-    register_103: int = 0
-    register_104: int = 0
-    register_105: int = 0
+    ConveyorHz: int = 0
+    MotorCurrentX10: int = 0
+    MotorTempX10: int = 0
+    VFDStatus: int = 0
+    ErrorCode: int = 0
 
 
 class IOResponse(BaseModel):

--- a/services/plc-modbus/tests/unit/test_backend_models.py
+++ b/services/plc-modbus/tests/unit/test_backend_models.py
@@ -16,7 +16,13 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from backend.models.plc_models import RegisterData  # noqa: E402
+from backend.models.plc_models import (  # noqa: E402
+    CoilData,
+    InputData,
+    IOResponse,
+    OutputData,
+    RegisterData,
+)
 
 _PLC_CONNECTION = os.path.join(
     os.path.dirname(__file__), "..", "..", "backend", "services", "plc_connection.py"
@@ -69,3 +75,29 @@ class TestRegisterDataMatchesSource:
             assert not field.startswith("register_"), (
                 "placeholder field %r reintroduced — this is the #161 bug" % field
             )
+
+    def test_io_response_serializes_named_vfd_fields(self):
+        """#161 acceptance at the API boundary: the serialized IOResponse —
+        what /api/plc/io actually returns — keeps every named VFD register
+        nonzero when the PLC reports real data. Built from the exact
+        `registers` dict shape read_io()/mock mode produce; no
+        plc_connection import (that would drag in pymodbus)."""
+        registers = {
+            "ItemCount": 42,
+            "ConveyorHz": 583,
+            "MotorCurrentX10": 27,
+            "MotorTempX10": 415,
+            "VFDStatus": 1,
+            "ErrorCode": 3,
+        }
+        response = IOResponse(
+            coils=CoilData(Conveyor=True, RunCommand=True),
+            inputs=InputData(DI_02=True),
+            outputs=OutputData(),
+            registers=RegisterData(**registers),
+            timestamp="2026-08-02T10:00:00Z",
+        )
+        serialized = response.model_dump()["registers"]
+        assert serialized == registers
+        for name in ("ConveyorHz", "MotorCurrentX10", "MotorTempX10", "VFDStatus", "ErrorCode"):
+            assert serialized[name] != 0, "%s zeroed in serialized IOResponse" % name

--- a/services/plc-modbus/tests/unit/test_backend_models.py
+++ b/services/plc-modbus/tests/unit/test_backend_models.py
@@ -1,0 +1,71 @@
+"""Regression tests for backend API models — issue #161.
+
+RegisterData declared placeholder fields (register_101..105) while
+plc_connection.read_io() produces the NAMED VFD fields from REGISTER_NAMES.
+Pydantic v2 silently drops unknown fields, so every named value was stripped
+from /api/plc/io and replaced with the 0 default — diagnosis read zeros while
+the PLC reported real data.
+
+These tests pin the model to the source of truth so the two cannot drift
+apart silently again.
+"""
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from backend.models.plc_models import RegisterData  # noqa: E402
+
+_PLC_CONNECTION = os.path.join(
+    os.path.dirname(__file__), "..", "..", "backend", "services", "plc_connection.py"
+)
+
+
+def _register_names_from_source():
+    """REGISTER_NAMES parsed from plc_connection.py's source.
+
+    Parsed rather than imported: importing plc_connection pulls in pymodbus,
+    which this pure-model test must not depend on. The dict literal is the
+    source of truth read_io() builds its response from.
+    """
+    with open(_PLC_CONNECTION, encoding="utf-8") as fh:
+        src = fh.read()
+    block = re.search(r"REGISTER_NAMES\s*=\s*\{(.*?)\}", src, re.DOTALL)
+    assert block, "REGISTER_NAMES not found in plc_connection.py"
+    names = re.findall(r'\d+\s*:\s*"([A-Za-z0-9_]+)"', block.group(1))
+    assert names, "REGISTER_NAMES parsed empty"
+    return names
+
+
+class TestRegisterDataMatchesSource:
+    def test_model_fields_equal_register_names(self):
+        """The model accepts exactly the names read_io() produces — no
+        placeholders, nothing dropped, nothing extra."""
+        expected = set(_register_names_from_source())
+        actual = set(RegisterData.model_fields)
+        assert actual == expected, (
+            "RegisterData fields %s != REGISTER_NAMES %s — Pydantic v2 drops "
+            "unknown fields, so any mismatch silently zeroes telemetry (#161)"
+            % (sorted(actual), sorted(expected))
+        )
+
+    def test_named_vfd_values_survive_round_trip(self):
+        """The exact dict shape read_io() emits keeps its values."""
+        payload = {
+            "ItemCount": 42,
+            "ConveyorHz": 583,
+            "MotorCurrentX10": 27,
+            "MotorTempX10": 415,
+            "VFDStatus": 2,
+            "ErrorCode": 0,
+        }
+        model = RegisterData(**payload)
+        assert model.model_dump() == payload
+
+    def test_no_placeholder_fields_remain(self):
+        for field in RegisterData.model_fields:
+            assert not field.startswith("register_"), (
+                "placeholder field %r reintroduced — this is the #161 bug" % field
+            )


### PR DESCRIPTION
Fixes #161 — the isolated bug-fix PR required by **PR 2 of MIRA PRD [#3048](https://github.com/Mikecranesync/MIRA/pull/3048)** (machine-evidence handoff, canonical-source correctness).

## The bug — verified live against current `main` before fixing

`read_io()` (`backend/services/plc_connection.py`) builds its registers dict from `REGISTER_NAMES`:

```
ItemCount, ConveyorHz, MotorCurrentX10, MotorTempX10, VFDStatus, ErrorCode
```

but `RegisterData` (`backend/models/plc_models.py`) declared placeholder `register_101..105` fields. **Pydantic v2 silently drops unknown fields**, so every named VFD value was stripped from `/api/plc/io` and replaced with the `0` default — diagnosis read zeros while the PLC reported real data.

## The fix

`RegisterData` now declares exactly the names `read_io()` produces. Repo-wide grep confirms the placeholder names had **zero consumers** outside the model itself, so this is a pure correction — no caller that worked before changes behavior.

## Regression coverage (`tests/unit/test_backend_models.py`, new)

- **Drift guard:** model fields pinned equal to `REGISTER_NAMES` *parsed from `plc_connection.py` source* (parsed, not imported, so the pure-model test carries no pymodbus dependency) — the two can never silently diverge again
- Round-trip test proving named values survive the model
- Guard against reintroducing `register_*` placeholders

**154 unit tests pass** (151 pre-existing + 3 new), run locally on the PLC laptop.

## Slice coordination

Claimed on MIRA #3048: PLC laptop (`LAPTOP-0KA3C70H`), session `f985f0fe`. Next in this slice: rebase/test the canonical-tag mapping from #188, then generate `factorylm.machine-snapshot.v1` fixtures. BRAVO holds MIRA-side PR 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgej4vU7mMnYTmU6QXsH3n
