### PR TITLE
ci(plc-modbus): run unit tests on PRs (#205)

### DIFF
--- a/.github/workflows/plc-modbus-tests.yml
+++ b/.github/workflows/plc-modbus-tests.yml
@@ -1,0 +1,22 @@
+name: PLC Modbus Tests
+
+on:
+  pull_request:
+    paths:
+      - "services/plc-modbus/**"
+      - ".github/workflows/plc-modbus-tests.yml"
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/plc-modbus
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e ".[dev,backend]"
+      - run: pytest tests/unit -q


### PR DESCRIPTION
Fixes #205.

PRs touching `services/plc-modbus` currently surface only the `brain-ingest` check, so the pytest evidence for PRs like #197/#198 has to be pasted into comments. This adds a minimal workflow that runs `pytest tests/unit -q` (Python 3.11, `pip install -e ".[dev,backend]"`) on any PR touching the service or the workflow itself.

- `backend` extras are included because `tests/unit/test_backend_models.py` needs pydantic/fastapi.
- Path-filtered so unrelated PRs don't pay the cost.
- Once this lands and #197/#198 are rebased or re-pushed, their suites will show up as real checks.

No production config, no deploy surface — CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dgej4vU7mMnYTmU6QXsH3n