### PR TITLE
fix(plc-modbus): comm health is its own signal; never claim a current E-stop across a dead link (#207)

### DIFF
--- a/services/plc-modbus/src/factorylm_plc/machine_snapshot.py
+++ b/services/plc-modbus/src/factorylm_plc/machine_snapshot.py
@@ -53,7 +53,59 @@ COMM_LOSS_ERROR_CODE = 5
 # Fields that would make the payload something other than pure observation.
 # validate_envelope rejects any of these at any depth (PRD: "No command,
 # write, actuator, or control field is permitted").
-FORBIDDEN_FIELD_TOKENS = ("command", "write", "actuate", "setpoint_write", "control")
+#
+# Matched on whole `_`-separated SEGMENTS, never as substrings (#207). A
+# substring test rejected ordinary PLC provenance -- `controller_model`,
+# `controller_serial`, `control_panel_id` all contain "control" -- while adding
+# nothing: a real command field is named `command`/`write`/`setpoint_write`, not
+# hidden inside `controller_`. That false-positive became live the moment MIRA
+# PR #3059 started writing snapshot fields into per-tag `metadata`.
+# Unambiguous command VERBS: any whole segment of a key matching one of these
+# makes the field a command, wherever it appears (`command`, `command_word`,
+# `setpoint_write`, `write_enable`, `actuator_state`).
+FORBIDDEN_FIELD_TOKENS = ("command", "write", "actuate", "actuator")
+
+# `control` is deliberately NOT a bare verb: `control_panel_id`,
+# `controller_model`, `controller_serial` are ordinary provenance. Only these
+# compound forms are the control-word shapes that would make the payload
+# actionable.
+FORBIDDEN_FIELD_NAMES = ("control_word", "control_bit", "control_register", "control_command")
+
+
+def _has_forbidden_segment(key: str) -> bool:
+    """True when `key` names a command field.
+
+    Matched on whole `_`-separated SEGMENTS, never as substrings (#207). The
+    substring test this replaces rejected ordinary PLC provenance --
+    `controller_model`, `control_panel_id` -- while adding nothing, because a
+    real command field is named for the verb (`command`, `setpoint_write`), not
+    hidden inside `controller_`. That false-positive went live the moment MIRA
+    PR #3059 began writing snapshot fields into per-tag `metadata`.
+    """
+    slug = _slug(str(key))
+    if slug in FORBIDDEN_FIELD_NAMES:
+        return True
+    return any(seg in FORBIDDEN_FIELD_TOKENS for seg in slug.split("_"))
+
+
+def comm_ok_from(snapshot: TagSnapshot) -> bool:
+    """THE one definition of communication health (#207).
+
+    Comms health is its own fact, not a value of the error register. When the
+    source supplies `TagSnapshot.comm_ok` (a real link indicator) that is
+    authoritative. Only when it is absent do we fall back to the historical
+    proxy -- `error_code == COMM_LOSS_ERROR_CODE` -- which is the ONLY signal
+    the Micro820 bridge exposes today.
+
+    Keeping the proxy behind one named function is the point: both this module
+    and `modbus_tag_source.canonical_tags_from_snapshot` call it, so the two
+    can never disagree about whether the link is up, and swapping in a real
+    indicator later is a one-line change in one place instead of a semantic
+    drift across two files.
+    """
+    if snapshot.comm_ok is not None:
+        return bool(snapshot.comm_ok)
+    return int(snapshot.error_code) != COMM_LOSS_ERROR_CODE
 
 
 def _slug(text: str) -> str:
@@ -73,15 +125,23 @@ def machine_state_from_snapshot(snapshot: TagSnapshot) -> Tuple[str, List[str]]:
     """
     conditions: List[str] = []
     code = int(snapshot.error_code)
+    comms_up = comm_ok_from(snapshot)
 
-    if bool(snapshot.e_stop):
-        conditions.append("e_stop_active")
-
-    if code == COMM_LOSS_ERROR_CODE:
+    if not comms_up:
+        # The E-stop reading crossed the same dead link as every other
+        # measurement, so it is last-known, NOT observed. `_tag_quality` already
+        # reasons this way for tag values; the condition list must agree.
+        # Asserting a CURRENT E-stop here is the dangerous direction: it can
+        # lead a technician to believe a machine is safed when it may have been
+        # released since comms dropped. Report it as last-known so the consumer
+        # can render the uncertainty instead of a false certainty (#207).
+        if bool(snapshot.e_stop):
+            conditions.append("e_stop_active_last_known")
         conditions.append(_slug(ERROR_CODES[COMM_LOSS_ERROR_CODE]))
         return "comm_down", conditions
 
     if bool(snapshot.e_stop):
+        conditions.append("e_stop_active")
         return "estopped", conditions
 
     if bool(snapshot.fault_alarm) or code != 0:
@@ -245,7 +305,7 @@ def validate_envelope(envelope: Any) -> List[str]:
         if isinstance(obj, dict):
             for key, val in obj.items():
                 lowered = str(key).lower()
-                if any(tok in lowered for tok in FORBIDDEN_FIELD_TOKENS):
+                if _has_forbidden_segment(lowered):
                     violations.append(
                         "forbidden command/write field %r at %s — the payload "
                         "is observation-only" % (key, path)

--- a/services/plc-modbus/src/factorylm_plc/modbus_tag_source.py
+++ b/services/plc-modbus/src/factorylm_plc/modbus_tag_source.py
@@ -137,6 +137,19 @@ def canonical_tag_name(raw_name: str) -> str | None:
     return None
 
 
+def _comm_ok_from(snapshot):
+    """Delegate to THE one definition of comm health (#207).
+
+    Imported lazily: `machine_snapshot` imports this module for
+    `REQUIRED_CANONICAL_TAGS` / `canonical_tags_from_snapshot`, so a top-level
+    import here would be circular. The point is that `conv_simple.comm_ok` and
+    `machine_state` can never disagree about whether the link is up.
+    """
+    from .machine_snapshot import comm_ok_from
+
+    return comm_ok_from(snapshot)
+
+
 def canonical_tags_from_snapshot(snapshot: TagSnapshot) -> dict[str, bool | int | float]:
     """Project a Micro820 snapshot into the Hub one-board canonical tags."""
     io = snapshot.io or {}
@@ -148,7 +161,7 @@ def canonical_tags_from_snapshot(snapshot: TagSnapshot) -> dict[str, bool | int 
         "conv_simple.vfd_speed_hz": int(speed_hz),
         "conv_simple.vfd_current_amps": float(snapshot.motor_current),
         "conv_simple.fault_code": int(snapshot.error_code),
-        "conv_simple.comm_ok": int(snapshot.error_code) != 5,
+        "conv_simple.comm_ok": _comm_ok_from(snapshot),
         "conv_simple.height_sensor_mm": int(io.get("height_sensor_mm", 0)),
         "conv_simple.sort_divert_active": bool(io.get("sort_divert_active", False)),
     }

--- a/services/plc-modbus/src/factorylm_plc/models.py
+++ b/services/plc-modbus/src/factorylm_plc/models.py
@@ -6,7 +6,7 @@ Provides dataclasses for representing machine state with LLM-ready formatting.
 
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 
 @dataclass
@@ -85,6 +85,12 @@ class TagSnapshot:
     coils: list[int] = field(default_factory=list)
     io: Dict[str, Any] = field(default_factory=dict)
     e_stop_ok: bool = False
+    # Communication health as its OWN signal, independent of `error_code`.
+    # `None` = this source has no link indicator, so consumers fall back to the
+    # documented error-code proxy (see machine_snapshot.comm_ok_from). A source
+    # that CAN observe the link directly sets this, and then a renumbering of
+    # ERROR_CODES cannot silently change what "comms are down" means (#207).
+    comm_ok: Optional[bool] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert snapshot to a JSON-serializable dictionary."""

--- a/services/plc-modbus/tests/unit/test_machine_snapshot.py
+++ b/services/plc-modbus/tests/unit/test_machine_snapshot.py
@@ -120,12 +120,21 @@ class TestMachineStateDerivation:
 
     def test_comm_loss_still_beats_e_stop(self):
         """With the link down the bridge cannot vouch for E-stop either —
-        comm_down stays dominant."""
+        comm_down stays dominant, and the E-stop is reported as LAST-KNOWN.
+
+        Updated for #207. This test previously asserted `e_stop_active`, which
+        contradicted the reasoning in its own docstring: if the bridge cannot
+        vouch for the E-stop, the envelope must not claim it is *currently*
+        active. Claiming an engaged E-stop that may have been released since
+        comms dropped is the direction that can lead a technician to believe a
+        machine is safed when it isn't.
+        """
         state, conditions = machine_state_from_snapshot(
             _snapshot(e_stop=True, error_code=5, fault_alarm=True)
         )
         assert state == "comm_down"
-        assert "e_stop_active" in conditions
+        assert "e_stop_active" not in conditions
+        assert "e_stop_active_last_known" in conditions
 
 
 class TestEnvelopeBuilder:
@@ -387,4 +396,77 @@ class TestObservationOnly:
             {"tag_path": "conv_simple.motor_run", "value": True, "quality": "good",
              "observed_at": "2026-08-02T10:00:00Z", "write_command": 1}
         )
+        assert any("forbidden" in v for v in validate_envelope(env))
+
+
+# ── Issue #207: state semantics ──────────────────────────────────────────────
+
+
+class TestCommHealthIsItsOwnSignal:
+    """Comm health must not BE error code 5 (#207 item 1)."""
+
+    def test_explicit_comm_ok_false_wins_over_a_clean_error_code(self):
+        snap = _snapshot(error_code=0, comm_ok=False)
+        state, conditions = machine_state_from_snapshot(snap)
+        assert state == "comm_down"
+        assert "communication_loss" in conditions
+
+    def test_explicit_comm_ok_true_wins_over_error_code_5(self):
+        """A source with a real link indicator says the link is UP; code 5 is
+        then an ordinary fault, not a comms verdict."""
+        snap = _snapshot(error_code=5, comm_ok=True)
+        state, _ = machine_state_from_snapshot(snap)
+        assert state == "faulted"
+
+    def test_error_code_5_remains_the_fallback_when_no_signal_is_supplied(self):
+        snap = _snapshot(error_code=5)
+        state, _ = machine_state_from_snapshot(snap)
+        assert state == "comm_down"
+
+    def test_renumbering_error_codes_cannot_change_machine_state(self):
+        """The proxy reads the CODE FOR communication loss, not the literal 5."""
+        from factorylm_plc import machine_snapshot as ms
+
+        assert ms.comm_ok_from(_snapshot(error_code=ms.COMM_LOSS_ERROR_CODE)) is False
+
+
+class TestNeverAssertACurrentEstopWithoutEvidence:
+    """#207 item 2 — the safety-relevant one."""
+
+    def test_comm_down_does_not_assert_a_current_estop(self):
+        snap = _snapshot(error_code=5, e_stop=True)
+        state, conditions = machine_state_from_snapshot(snap)
+        assert state == "comm_down"
+        assert "e_stop_active" not in conditions, (
+            "asserting a CURRENT E-stop across a dead link can lead a technician "
+            "to believe a machine is safed when it may have been released"
+        )
+        assert "e_stop_active_last_known" in conditions
+
+    def test_estop_is_asserted_normally_when_comms_are_good(self):
+        """Counterfactual — the guard must not suppress a real, observed E-stop."""
+        snap = _snapshot(error_code=0, e_stop=True)
+        state, conditions = machine_state_from_snapshot(snap)
+        assert state == "estopped"
+        assert "e_stop_active" in conditions
+        assert "e_stop_active_last_known" not in conditions
+
+
+class TestForbiddenFieldMatchingIsBoundaryAware:
+    """#207 item 3 — substring denylist false-positives on controller_*."""
+
+    def test_ordinary_plc_provenance_keys_are_not_rejected(self):
+        env = _envelope()
+        env["provenance"]["controller_model"] = "Micro820"
+        env["provenance"]["control_panel_id"] = "CP-1"
+        assert validate_envelope(env) == []
+
+    def test_a_genuine_command_field_is_still_rejected(self):
+        env = _envelope()
+        env["provenance"]["command"] = "start"
+        assert any("forbidden" in v for v in validate_envelope(env))
+
+    def test_a_genuine_write_field_is_still_rejected_at_depth(self):
+        env = _envelope()
+        env["tags"][0]["setpoint_write"] = 42
         assert any("forbidden" in v for v in validate_envelope(env))


### PR DESCRIPTION
Closes #207. Three review items from MIRA PRD #3048 that merged with #198 at the reviewed head, unaddressed. All three feed MIRA's technician-visible live evidence, so they gate promoting that feed as trusted.

## 1. Comm health was *being* error code 5 — in two places, independently

`machine_state_from_snapshot` branched on `code == COMM_LOSS_ERROR_CODE`, **and** `modbus_tag_source.canonical_tags_from_snapshot` separately derived `conv_simple.comm_ok` from `int(snapshot.error_code) != 5`. Two independent readings of the same register standing in for a different fact — renumbering `ERROR_CODES` would silently change what `machine_state` means, in two files, with nothing linking them.

`TagSnapshot` now carries an optional `comm_ok` link indicator, and **`comm_ok_from()` is the one definition** both call sites use: authoritative when the source supplies it, falling back to the documented error-code proxy only when absent.

Being straight about the limit: **the Micro820 bridge exposes no independent link signal today**, so the proxy is still what actually runs. What changed is that it is now one named, documented seam instead of two silent duplications — swapping in a real indicator is a one-line change in one place rather than a semantic drift across two files.

## 2. `e_stop_active` was asserted across a dead link — the safety one

```python
if bool(snapshot.e_stop):
    conditions.append("e_stop_active")   # unconditional
if code == COMM_LOSS_ERROR_CODE:
    ...
    return "comm_down", conditions
```

`_tag_quality` in the same file already reasons this correctly — with comms lost the values are "whatever the bridge last held", `uncertain`, excepting only `comm_ok`/`fault_code` as the bridge's *own* state. `e_stop` crosses the same dead link and got no such exception.

Direction matters: claiming an E-stop is **engaged** when it may have been released since comms dropped is the direction that can lead a technician to believe a machine is safed when it isn't. Now reported as `e_stop_active_last_known` so the consumer renders uncertainty rather than false certainty.

**A pre-existing test asserted the old behaviour while its own docstring said the opposite** — *"With the link down the bridge cannot vouch for E-stop either"* — and then `assert "e_stop_active" in conditions`. Updated to match its stated reasoning.

## 3. Substring denylist rejected ordinary provenance

`FORBIDDEN_FIELD_TOKENS` was substring-matched over every key at every depth, so `controller_model`, `controller_serial` and `control_panel_id` were all rejected as "forbidden command/write field". Live rather than theoretical since MIRA #3059 began writing snapshot fields into per-tag `metadata`.

Now matched on whole `_`-separated segments. My first pass at this was still wrong — segment-matching alone still rejects `control_panel_id`, because bare `control` is genuinely ambiguous. Dropped it as a verb and named the actual control-word shapes (`control_word`, `control_bit`, `control_register`, `control_command`) explicitly. A real `command` / `write` / `actuate` / `setpoint_write` field is still rejected at any depth.

## Evidence

- **195 passed on `origin/main` → 204 passed here (+9), zero regressions.** Baseline measured on a clean detached checkout of `4521224`, not assumed.
- Counterfactuals included throughout so the guards can't pass by rejecting everything: an observed E-stop with good comms still asserts `e_stop_active` and `estopped`; a genuine command field is still rejected.
- Local runs on Python 3.12 (CHARLIE's system `python3` is 3.9 and can't import this package — `Dict[str, Any] | None`). CI runs 3.11.

No behaviour change for a healthy snapshot. No new dependency, no wire-format change: `comm_ok` is additive and optional, and the envelope shape is untouched.
