### PR TITLE
ops: Claude insights tracker + cluster-wide hardening

### DIFF
--- a/.github/workflows/insights-tooling-tests.yml
+++ b/.github/workflows/insights-tooling-tests.yml
@@ -1,0 +1,25 @@
+name: insights-tooling-tests
+
+# Runs the verify_green / agent_claim test suites on PRs that touch them.
+# -v is deliberate: verify_green.py asserts new test NAMES appear in CI logs.
+on:
+  pull_request:
+    paths:
+      - "scripts/verify_green.py"
+      - "scripts/agent_claim.py"
+      - "tests/test_verify_green.py"
+      - "tests/test_agent_claim.py"
+      - ".github/workflows/insights-tooling-tests.yml"
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install pytest
+        run: python -m pip install pytest
+      - name: Run insights tooling tests
+        run: python -m pytest tests/test_verify_green.py tests/test_agent_claim.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ _BUILDS/
 
 # Serena memories (local)
 .serena/memories/
+
+# Runtime work-claim leases (scripts/agent_claim.py) — session-local state, never committed
+.agents/leases/
+.verify_green/

--- a/.planning/task_queue/TASK-2026-08-23-AGENT-CLAIM.md
+++ b/.planning/task_queue/TASK-2026-08-23-AGENT-CLAIM.md
@@ -1,0 +1,35 @@
+# TASK-2026-08-23-AGENT-CLAIM
+
+## Why this exists
+Insights reports 2026-08-09 and 2026-08-23: parallel Claude sessions rebuilt PRs a
+concurrent session had already merged ("prs are already done are you just duplicating?").
+A lease/claim ledger makes duplicate work structurally impossible.
+
+## Context / SSoT
+- docs/insights/README.md (this branch) — tracker
+- ~/.claude/usage-data/hardening-plan-2026-08-23.md — spec source ("strategy 2")
+- Pattern precedent: per-run dated fragment files (the wiki/hot.md conflict fix)
+
+## Deliverable
+`scripts/agent_claim.py` — stdlib-only Python 3.9 (`Optional[X]`, not `X | None`).
+Leases live in `.agents/leases/<item-slug>.json`:
+`{agent_id, item, worktree, branch, started_at, heartbeat_at, status}`.
+Subcommands:
+- `claim <item> [--agent-id X] [--worktree P] [--branch B]` — atomic via
+  `os.open(O_CREAT|O_EXCL)`. Fails (exit 1) if a lease exists with heartbeat fresher
+  than `--stale-hours` (default 4). PREFLIGHT before claiming: run
+  `gh pr list --state all --search <item>` and `git log --all --grep=<item> --oneline`;
+  refuse the claim (exit 2, distinct message) if the work already appears merged.
+  A `--no-preflight` flag skips this for offline use.
+- `heartbeat <item>` — update heartbeat_at.
+- `release <item> [--status merged|abandoned]` — remove lease, append one line to
+  `.agents/leases/HISTORY.log`.
+- `census` — table of live vs stale leases; `--reap` deletes stale ones.
+Timestamps: UTC ISO-8601.
+
+## Acceptance criteria (measurable)
+- pytest `tests/test_agent_claim.py`: claim/release round-trip; second claim on fresh
+  lease fails; stale lease is claimable; census classifies fresh vs stale; the
+  atomic-claim race — two claimants racing for one item (threads or sequential
+  O_EXCL simulation) — exactly one wins. gh/git preflight mocked; no network in tests.
+- `python3 -m py_compile scripts/agent_claim.py` passes on Python 3.9.

--- a/.planning/task_queue/TASK-2026-08-23-VERIFY-GREEN.md
+++ b/.planning/task_queue/TASK-2026-08-23-VERIFY-GREEN.md
@@ -1,0 +1,34 @@
+# TASK-2026-08-23-VERIFY-GREEN
+
+## Why this exists
+Three usage-insights reports (2026-07-06, 2026-08-09, 2026-08-23) identify premature
+"green and done" claims as the #1 friction: green CI badges read against a stale SHA,
+required checks that silently skipped, new tests that never executed, workflows that
+no-opped on missing deps. This task makes "green" a machine-checked verdict.
+
+## Context / SSoT
+- docs/insights/README.md (this branch) — tracker
+- ~/.claude/usage-data/hardening-plan-2026-08-23.md — spec source ("strategy 1")
+- /ship skill Step 1 — the manual checklist this script automates
+
+## Deliverable
+`scripts/verify_green.py <pr-number> [--repo owner/name]` — stdlib-only Python 3.9
+(`Optional[X]`, not `X | None`), shells out to `gh` CLI. Exit 0 only if ALL hold:
+1. Newest completed check-run set reports against the PR's CURRENT head
+   (`gh pr view --json headRefOid` == the SHA the runs report for).
+2. Every required/reported check concluded `success` — `skipped`/`neutral`/`cancelled`
+   on any check is enumerated and FAILS the verdict.
+3. If the PR diff adds test functions (parse `gh pr diff` for `^+\s*def test_`),
+   each new test name must appear in the CI run logs (`gh run view --log`).
+4. Run logs contain none of: `ModuleNotFoundError`, `command not found`.
+Writes JSON verdict `{pr, sha, checks:[{name,conclusion}], tests_added, tests_found_in_log, verdict}`
+to stdout and to `.verify_green/<pr>-<sha>.json`. Non-zero exit + reason on any failure.
+
+## Acceptance criteria (measurable)
+- `python3 scripts/verify_green.py --self-test` runs offline unit checks of the pure
+  functions (SHA compare, conclusion classification, new-test extraction from a diff
+  string, log scanning) and prints PASS; exit 0.
+- pytest file `tests/test_verify_green.py` covers: stale-SHA fail, skipped-check fail,
+  missing-test-in-log fail, ModuleNotFoundError fail, all-good pass — mocking gh calls.
+- `python3 -m py_compile scripts/verify_green.py` passes on Python 3.9.
+- No network/gh calls in tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,6 +169,16 @@ Features, Antfarm workflows, and the `telegram_trainer` skill all operate within
 
 For cluster topology, the 7 Laws, and ops procedures see **[CLUSTER.md](CLUSTER.md)**.
 
+## Claude Improvement Tracker (insights-derived hardening)
+
+Usage-insights reports and their implementations are tracked in
+**[docs/insights/README.md](docs/insights/README.md)** — check it before
+implementing any insights recommendation (it may already exist). The
+cluster-wide rules, hooks, and skills live in **[infra/claude/](infra/claude/README.md)**;
+install/update on any node with `bash ~/factorylm/infra/claude/install.sh`.
+Key tools: `scripts/verify_green.py <pr>` (machine-checked green verdict),
+`scripts/agent_claim.py` (work-claim ledger so parallel sessions never duplicate).
+
 ---
 
 ## Active Focus Window (Revenue Priority)

--- a/docs/insights/2026-07-06-output-limits-and-isolation.md
+++ b/docs/insights/2026-07-06-output-limits-and-isolation.md
@@ -1,0 +1,22 @@
+# Insights 2026-07-06 — Output Limits, Worktree Isolation, Permission Gates
+
+Report file no longer on disk; findings reconstructed from the rules it produced
+(dated 2026-07-06 in CHARLIE's `~/.claude/CLAUDE.md`).
+
+## Findings
+
+1. **~12 sessions over 28 days died as unrecoverable API errors** from exceeding
+   the output-token ceiling mid-response — the single biggest source of lost work.
+2. **Two incidents of a dispatched subagent mutating the shared checkout** instead
+   of an isolated one, nearly destroying uncommitted work.
+3. **Permission-gate looping**: a session repeatedly deferred an already-authorized
+   prod action until the user had to demand it; another silently routed around a
+   blocked tool instead of surfacing the block.
+
+## Implementations
+
+| Fix | Artifact | Status |
+|---|---|---|
+| Long artifacts → Write to file + short pointer reply; checkpoint long runs to `.planning/STATE.md` | `infra/claude/CLAUDE-GLOBAL-RULES.md` § Output Length | ✅ |
+| Subagents that Edit/Write get a worktree, or the shared checkout is verified clean first | § Subagent Worktree Isolation | ✅ |
+| Blocked action → act if within standing authorization, else ask once and act on the answer; never loop or evade | § Permission Gates | ✅ |

--- a/docs/insights/2026-08-09-verification-and-parallelism.md
+++ b/docs/insights/2026-08-09-verification-and-parallelism.md
@@ -1,0 +1,34 @@
+# Insights 2026-08-09 — Verification, Parallel Sessions, Environment Traps
+
+Source: `report-2026-08-09-062029.html` (CHARLIE `~/.claude/usage-data/`).
+30 sessions analyzed, 2026-07-08 → 2026-08-04. 169 commits, 705h wall-clock,
+4,643 Bash calls.
+
+## Top friction
+
+1. **Premature "done" / false-green** (14 buggy-code events): PR #3023 declared
+   "green and done" with uninvestigated hazards; its own fix shipped three real
+   bool/NaN/inf defects; new tests trusted without confirming they executed;
+   ruff-format CI failures never run locally.
+2. **Parallel sessions colliding**: PRs 4 and 5 rebuilt after a concurrent session
+   had already merged them; VERSION/CHANGELOG rebase conflicts across 4+ sessions;
+   a #3051 smoke failure caused by a concurrent #3067 prod deploy.
+3. **Environment traps on unattended runs**: seven orphaned pyright workers pinning
+   CPU; Colima down; gh auth expired twice; missing tesseract tainting a benchmark
+   lane; a Stop hook that deadlocked by text-matching its own goal snippet.
+
+## Recommendations → implementations
+
+| Recommendation | Artifact | Status |
+|---|---|---|
+| Definition of Done: named CI checks, tests-provably-ran, local lint, explicit hazards | `/ship` skill + `CLAUDE-GLOBAL-RULES.md` § Verification Discipline + `scripts/verify_green.py` | ✅ |
+| Parallel-session check before implementing | `/resume` skill + § Resume Reconciliation | ✅ |
+| Shared-file conflict policy (dated fragments) | § Shared-File Policy + `infra/claude/hooks/shared-file-guard.sh` | ✅ |
+| Stop re-diagnosing | § Diagnose Once, Then Act | ✅ |
+| Deploy verification end-to-end (dead-staging-layer check) | `/ship` behavioral-diff step | ✅ |
+| PostToolUse ruff hook | `infra/claude/hooks/ruff-on-edit.sh` | ✅ |
+| SessionStart environment preflight | `/resume` Step 4 + `infra/claude/hooks/reap-orphaned-lsp.sh` | ✅ |
+| Claim ledger for parallel agents | `scripts/agent_claim.py` | ✅ |
+| Evidence-gated merge (test-ID assertion in CI logs) | `scripts/verify_green.py` | ✅ |
+| Mutation testing scoped to diff | — | ⬜ deferred (heavy; revisit if false-green recurs) |
+| Overnight self-healing backlog operator | phase template in 2026-08-23 entry | 🟡 prompt discipline |

--- a/docs/insights/2026-08-23-hardening.md
+++ b/docs/insights/2026-08-23-hardening.md
@@ -1,0 +1,50 @@
+# Insights 2026-08-23 — Hardening Pass
+
+Source: `report-2026-08-23-072714.html` (CHARLIE `~/.claude/usage-data/`).
+31 sessions analyzed, 2026-07-15 → 2026-08-19. 214 commits, 1,101h, 5,625 Bash calls.
+Same top frictions as 2026-08-09 (premature green, duplicated parallel work,
+environment stalls) — this pass turned the habits into enforcement.
+
+## Implemented (live on CHARLIE 2026-08-23; distributed via `infra/claude/`)
+
+| Item | Artifact | What it kills |
+|---|---|---|
+| Orphaned pyright/LSP reaper (SessionStart hook) | `infra/claude/hooks/reap-orphaned-lsp.sh` | CPU-thrash rediscovery (3 sessions). Kills only launchd-orphaned, TTY-less, >30-min LSP workers; logs to `~/.claude/reaped.log`; ctkd report-only. |
+| Shared-file guard (PreToolUse hook) | `infra/claude/hooks/shared-file-guard.sh` | VERSION/CHANGELOG/hot.md conflict tax. Direct repo-root edits become a one-click permission prompt. Bypass: `CLAUDE_ALLOW_SHARED_FILE_EDITS=1`. |
+| Ruff at edit time + unfixable-error feedback | `infra/claude/hooks/ruff-on-edit.sh` | Avoidable red-CI reruns; unfixable lint errors surface to the model immediately. |
+| Verification Discipline rules | `infra/claude/CLAUDE-GLOBAL-RULES.md` | Stale-SHA green badges, phantom test runs, silent hazard omission — the #1 friction. |
+| `/resume` skill | `infra/claude/skills/resume/SKILL.md` | Duplicated PRs from stale handoffs; auth/service preflight before work. |
+| `/ship` hardened | `infra/claude/skills/ship.md` | SHA-pinned CI gate, tests-executed grep, hazard ledger, staging before/after behavioral diff. |
+| `verify_green.py` | `scripts/verify_green.py` | Unfakeable green: SHA match, no skipped checks, new tests present in logs, no silent no-ops. JSON verdict artifact. |
+| `agent_claim.py` claim ledger | `scripts/agent_claim.py` + `.agents/leases/` | Parallel-session duplicate work. Atomic O_EXCL claim with merged-work preflight, heartbeat, stale reaping. |
+
+## Adoption notes
+
+- `verify_green.py` is generic (`gh`-based, `--repo` flag). For the MIRA repo,
+  wire it as a required step in the merge-pr/ship flow there; optionally add a
+  Stop hook blocking session end on an unverified "ready to merge" claim.
+- `agent_claim.py`: run `census` at session start, `claim` before implementation
+  work. The claim preflight (refuses items already merged) is the direct fix for
+  the duplicated-PRs incident.
+
+## Machine-checked handoff format (convention)
+
+Handoffs are a table, not prose: `item | PR# | branch | head SHA | CI state |
+blocking hazard | next action`, plus a "verify before resuming" code block with
+the exact gh/git commands re-checking every row. `/resume` consumes this mechanically.
+
+## Overnight close-the-loop phase template (prompt discipline until automated)
+
+1. **Baseline**: 8–10 live staging probes captured before any code. Staging already
+   broken → STOP (never build on a dead layer).
+2. **TDD**: failing tests first; full suite, not just the new file.
+3. **Verify**: `verify_green.py` — SHA-pinned, no skips, tests provably ran.
+4. **Behavioral diff**: deploy staging, settle, re-run probes. Identical output = failure.
+5. **Promote or revert**: prod only on intended diff, rollback checkpoint,
+   tag == VERSION == deployed; else auto-revert + file issue with evidence.
+6. **Handoff**: table format, before/after probe outputs, explicit uninvestigated-hazard list.
+
+## Confirmed-working patterns (do not change)
+
+Handoff-driven continuity, class-level fixes over instance patches, refusing
+unverified "done" — now encoded as hooks/skills/scripts rather than habits.

--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -1,0 +1,48 @@
+# Claude Improvement Tracker
+
+Every Claude Code usage-insights report we run gets an entry here, with each
+recommendation tracked to a concrete, verifiable implementation. This is the
+single place any session (or human) checks what has already been fixed, so the
+same lesson is never re-learned and the same tooling is never rebuilt.
+
+**Rule for future sessions:** before implementing anything suggested by an
+insights report, check this tracker AND `gh pr list --state all --search <keyword>`.
+If it's listed as implemented, verify the artifact still exists and move on.
+
+## Reports
+
+| Report | Period | Entry |
+|---|---|---|
+| 2026-07-06 | ~28 days to 2026-07-06 | [2026-07-06-output-limits-and-isolation.md](2026-07-06-output-limits-and-isolation.md) |
+| 2026-08-09 | 2026-07-08 → 2026-08-04 | [2026-08-09-verification-and-parallelism.md](2026-08-09-verification-and-parallelism.md) |
+| 2026-08-23 | 2026-07-15 → 2026-08-19 | [2026-08-23-hardening.md](2026-08-23-hardening.md) |
+
+## Implementation status (consolidated, as of 2026-08-23)
+
+| Recommendation (first appeared) | Status | Artifact |
+|---|---|---|
+| Long artifacts to file, never one giant chat response (07-06) | ✅ Implemented | `infra/claude/CLAUDE-GLOBAL-RULES.md` § Output Length |
+| Subagent worktree isolation (07-06) | ✅ Implemented | § Subagent Worktree Isolation |
+| Surface permission blocks once, never loop/evade (07-06) | ✅ Implemented | § Permission Gates |
+| Verify subagent output against the code index (07-06 era) | ✅ Implemented | § Verify Subagent Output |
+| Reconcile handoff vs repo state before working (08-09, 08-23) | ✅ Implemented | `/resume` skill — `infra/claude/skills/resume/SKILL.md` |
+| SHA-pinned green + tests-actually-ran + hazard ledger (08-09, 08-23) | ✅ Implemented | `/ship` skill + `scripts/verify_green.py` |
+| Machine-checked "green" verdict script (08-09, 08-23) | ✅ Implemented | `scripts/verify_green.py` (see entry for adoption notes) |
+| Ruff format/lint at edit time, not CI time (08-09, 08-23) | ✅ Implemented | `infra/claude/hooks/ruff-on-edit.sh` |
+| Shared-file (VERSION/CHANGELOG/hot.md) edit guard (08-09, 08-23) | ✅ Implemented | `infra/claude/hooks/shared-file-guard.sh` |
+| Orphaned pyright/LSP reaper at session start (08-23) | ✅ Implemented | `infra/claude/hooks/reap-orphaned-lsp.sh` |
+| Stop re-diagnosing / timebox analysis (08-09, 08-23) | ✅ Implemented | § Diagnose Once, Then Act |
+| Environment preflight (gh auth, Docker, services) (08-09) | ✅ Implemented | `/resume` skill Step 4 |
+| Claim ledger for parallel sessions (08-09, 08-23) | ✅ Implemented | `scripts/agent_claim.py` + `.agents/leases/` |
+| Machine-checked handoff table format (08-23) | 🟡 Adopted as convention | `/resume` reconciles any handoff; table format documented in 08-23 entry |
+| Overnight close-the-loop (baseline → behavioral diff → promote/revert) (08-09, 08-23) | 🟡 Prompt discipline | Phase template in 08-23 entry; automate once `verify_green.py` is adopted in target-repo CI |
+| Mutation testing scoped to diff (08-09) | ⬜ Not built | Deliberate: heavy; revisit if false-green recurs after verify_green adoption |
+
+## Distribution — how every session finds this
+
+- **Any session in this repo**: root `CLAUDE.md` points here.
+- **Any session on any cluster node**: `infra/claude/install.sh` installs the
+  hooks + skills into `~/.claude/` and links `CLAUDE-GLOBAL-RULES.md` into the
+  node's global `~/.claude/CLAUDE.md`. Nodes already pull this repo
+  (`git -C ~/factorylm pull`), so `git pull && bash infra/claude/install.sh`
+  is the full update path. See `infra/claude/README.md`.

--- a/infra/claude/CLAUDE-GLOBAL-RULES.md
+++ b/infra/claude/CLAUDE-GLOBAL-RULES.md
@@ -1,0 +1,86 @@
+# Claude Global Rules (insights-derived, cluster-wide)
+
+Canonical copy — installed into each node's `~/.claude/CLAUDE.md` via an
+`@import` line by `infra/claude/install.sh`. Provenance and tracking:
+`docs/insights/README.md`.
+
+## Verification Discipline — "green" and "done" are machine-checked claims
+
+- Never report a PR or CI run as green without confirming the check-run SHA
+  equals the PR's **current** head: `gh pr view <n> --json headRefOid` must match
+  the SHA on the green run. A badge from the previous head is not green.
+- A green run is not proof new tests executed. Grep the CI log for the new test
+  names (or diff junit test counts vs base) before declaring done. Also grep run
+  logs for `ModuleNotFoundError` / `command not found` / suspiciously-fast suite
+  steps — workflows have silently no-opped for weeks.
+- Prefer `scripts/verify_green.py <pr>` (this repo) — it checks all of the above
+  mechanically and emits a JSON verdict.
+- For any user-facing feature: hit the real staging endpoint end-to-end and
+  capture observable output BEFORE and AFTER. Identical output = failure to
+  prove, not success — trace the request path until you find where it diverges.
+- Before saying "done", emit a **hazard ledger**: every hazard/TODO/"probably
+  fine" noticed but not fixed, each dispositioned as `fixed | filed as issue #N |
+  explicitly accepted because <reason>`. Silent omission is an overclaim.
+
+## Resume-from-Handoff Reconciliation
+
+Handoff docs go stale and parallel sessions land work (a session once rebuilt
+two already-merged PRs). Before acting on ANY handoff or resuming any
+workstream: `git fetch --all`, `git log --oneline origin/main -30`, and
+`gh pr list --state all --limit 30 --json number,title,state,mergedAt`. Diff the
+handoff's claims against reality, report what's already merged/closed, and only
+then propose the remaining work list. The `/resume` skill encodes this — use it.
+For parallel sessions, claim work items first: `scripts/agent_claim.py claim <item>`.
+
+## Diagnose Once, Then Act
+
+Timebox diagnosis: at most ~15 tool calls to a written one-paragraph root-cause
+statement citing the specific evidence lines, then implement the fix. Reopen the
+diagnosis only if the fix fails, and say explicitly what new evidence changed
+your mind. One decisive fix beats repeated analysis passes.
+
+## Local Gates Before Push
+
+Before any `git push` in a Python repo: `ruff format --check . && ruff check . &&
+pytest -q` — the FULL suite, not just the new test file (new tests have passed in
+isolation and failed under full-suite module pollution). A PostToolUse hook
+auto-formats each edited .py and reports unfixable lint errors — but it can't run
+the test suite; that's on you.
+
+## Shared-File Conflict Policy
+
+Never edit `VERSION`, `CHANGELOG.md`, or `wiki/hot.md` directly in a feature
+branch. Use per-run dated fragment files (`changelog.d/<date>-<slug>.md`); a
+release job assembles them. A PreToolUse hook (`shared-file-guard.sh`) turns
+direct edits at a repo root into an explicit permission prompt; set
+`CLAUDE_ALLOW_SHARED_FILE_EDITS=1` where direct edits are legitimately fine.
+A rebase conflict on one of these files means the policy was violated — fix the
+source, don't hand-resolve.
+
+## Output Length & Long Autonomous Runs
+
+Long artifacts (reports, plans, audit writeups) go to a file via Write/Edit with
+a short pointer + 2-3 line summary in chat — never one giant chat response
+(~12 sessions died mid-response on the output-token ceiling). Long autonomous
+runs checkpoint progress to `.planning/STATE.md` (or equivalent) every phase.
+
+## Subagent Worktree Isolation
+
+Before dispatching any subagent that will Edit/Write files — especially several
+in parallel — give it its own git worktree (Agent tool `isolation: "worktree"`
+or `git worktree add`) or explicitly confirm the shared checkout has no
+uncommitted work it could clobber. Never assume isolation — verify it.
+
+## Verify Subagent Output
+
+Subagents fabricate symbols. After ANY agent returns code, before committing:
+confirm every referenced symbol, import, signature, DB column, and state value
+exists (codegraph or grep). Reject and regenerate code referencing symbols you
+cannot ground.
+
+## Permission Gates
+
+Don't silently loop, retry, or route around a permission/classifier block. If
+the action is within a standing authorization, do it. If the gate is right to
+flag it, ask the user once — exactly what's blocked and why — and act on the
+answer. Fix the looping, keep the guardrail.

--- a/infra/claude/README.md
+++ b/infra/claude/README.md
@@ -1,0 +1,36 @@
+# infra/claude — Cluster-wide Claude Code Hardening
+
+Canonical, version-controlled home of the Claude improvements derived from
+usage-insights reports. Tracking and provenance: [`docs/insights/`](../../docs/insights/README.md).
+
+## Contents
+
+| Path | What |
+|---|---|
+| `CLAUDE-GLOBAL-RULES.md` | Insights-derived working rules, imported into each node's `~/.claude/CLAUDE.md` |
+| `hooks/reap-orphaned-lsp.sh` | SessionStart: reap orphaned pyright/LSP workers (logs to `~/.claude/reaped.log`) |
+| `hooks/shared-file-guard.sh` | PreToolUse: VERSION/CHANGELOG/hot.md edits become a permission prompt |
+| `hooks/ruff-on-edit.sh` | PostToolUse: auto-format .py edits, feed unfixable lint errors back to the model |
+| `skills/resume/SKILL.md` | `/resume` — reconcile handoff vs repo state + env preflight before any work |
+| `skills/ship.md` | `/ship` — SHA-pinned CI gate, hazard ledger, behavioral diff, merge & deploy |
+| `install.sh` | Idempotent installer for all of the above |
+
+Related repo tooling (installed nowhere — invoked by path):
+- `scripts/verify_green.py <pr>` — machine-checked green verdict (SHA-pinned, no
+  skipped checks, new tests provably executed, no silent no-ops)
+- `scripts/agent_claim.py` — atomic work-claim ledger for parallel sessions
+
+## Install / update on any node
+
+```bash
+git -C ~/factorylm pull
+bash ~/factorylm/infra/claude/install.sh
+```
+
+Idempotent. New sessions pick everything up automatically; already-running
+sessions need `/hooks` opened once (or a restart) to load new hook registrations.
+
+## Editing policy
+
+Edit the copies HERE, ship via PR, then re-run `install.sh` on each node —
+never hand-edit `~/.claude/hooks/` copies, they get overwritten on the next install.

--- a/infra/claude/hooks/reap-orphaned-lsp.sh
+++ b/infra/claude/hooks/reap-orphaned-lsp.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# SessionStart hook: reap orphaned pyright / language-server workers.
+#
+# Motivation: orphaned pyright workers (and once a wedged ctkd daemon) caused
+# CPU thrashing that three separate sessions burned time re-diagnosing.
+# This makes the cleanup automatic instead of a rediscovery each time.
+#
+# Safety rules — a process is only killed if ALL hold:
+#   1. Its command line matches a known language-server worker pattern
+#      (pyright/langserver). ctkd is system-owned, so it is only REPORTED,
+#      never killed (no passwordless sudo on this box anyway).
+#   2. It is orphaned: parent PID is 1 (launchd adopted it).
+#   3. It is older than 30 minutes.
+#   4. It is not attached to a terminal (TTY column is "??").
+# Everything killed (or flagged) is logged to ~/.claude/reaped.log.
+
+LOG="$HOME/.claude/reaped.log"
+NOW=$(date +%s)
+
+# etime is [[dd-]hh:]mm:ss — convert to seconds
+etime_to_secs() {
+  local e="$1" d=0 h=0 m=0 s=0 rest
+  if [[ "$e" == *-* ]]; then d=${e%%-*}; e=${e#*-}; fi
+  IFS=: read -r a b c <<< "$e"
+  if [[ -n "$c" ]]; then h=$a; m=$b; s=$c
+  elif [[ -n "$b" ]]; then m=$a; s=$b
+  else s=$a; fi
+  echo $(( 10#$d*86400 + 10#$h*3600 + 10#$m*60 + 10#$s ))
+}
+
+ps -axo pid=,ppid=,etime=,tty=,command= | grep -Ei 'pyright|langserver' | grep -v grep | \
+while read -r pid ppid etime tty cmd; do
+  [ "$ppid" = "1" ] || continue
+  [ "$tty" = "??" ] || continue
+  age=$(etime_to_secs "$etime")
+  [ "$age" -gt 1800 ] || continue
+  if kill "$pid" 2>/dev/null; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') killed pid=$pid age=${age}s cmd=${cmd:0:120}" >> "$LOG"
+  fi
+done
+
+# ctkd: report-only (system daemon; killing needs sudo and may be wrong fix)
+CTKD_CPU=$(ps -axo pcpu=,command= | awk '/[c]tkd/ {print int($1); exit}')
+if [ -n "$CTKD_CPU" ] && [ "$CTKD_CPU" -gt 50 ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') WARNING ctkd at ${CTKD_CPU}% CPU — wedged? (not killed, needs sudo)" >> "$LOG"
+  echo "{\"systemMessage\": \"ctkd daemon is at ${CTKD_CPU}% CPU — likely wedged, see ~/.claude/reaped.log\"}"
+fi
+exit 0

--- a/infra/claude/hooks/ruff-on-edit.sh
+++ b/infra/claude/hooks/ruff-on-edit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# PostToolUse hook: auto-format and lint Python files after Edit/Write.
+#
+# Payload source: stdin JSON. $CLAUDE_TOOL_INPUT is NOT set by the harness
+# (verified 2026-08-09 by dumping the hook environment: CLAUDE_PROJECT_DIR /
+# CLAUDE_CODE_SESSION_ID / CLAUDE_PID are set; CLAUDE_TOOL_INPUT is empty and
+# CLAUDE_FILE_PATH is absent entirely). This hook read only that env var, so it
+# had never run in any project. Its jq path was wrong too — the payload nests the
+# path under .tool_input / .tool_response, not at the top level — so it would
+# still have missed even with the variable populated.
+JQ=/opt/homebrew/bin/jq
+[ -x "$JQ" ] || JQ=jq
+
+FILE=$(cat | "$JQ" -r '.tool_response.filePath // .tool_input.file_path // empty' 2>/dev/null)
+
+if [[ "$FILE" == *.py ]] && [[ -f "$FILE" ]]; then
+  /opt/homebrew/bin/ruff check --fix "$FILE" >/dev/null 2>&1 || true
+  /opt/homebrew/bin/ruff format "$FILE" >/dev/null 2>&1 || true
+  # Surface anything ruff could NOT auto-fix back to the model now,
+  # instead of letting it be discovered as a red CI check later.
+  REMAINING=$(/opt/homebrew/bin/ruff check --output-format=concise "$FILE" 2>/dev/null | head -20)
+  if [ -n "$REMAINING" ]; then
+    "$JQ" -n --arg r "$REMAINING" '{
+      hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: ("ruff auto-fix left unresolved lint errors in this file — fix them before moving on:\n" + $r)
+      }
+    }'
+  fi
+fi
+exit 0

--- a/infra/claude/hooks/shared-file-guard.sh
+++ b/infra/claude/hooks/shared-file-guard.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# PreToolUse hook (Edit|Write): guard direct edits to shared conflict-magnet
+# files — VERSION and CHANGELOG.md at a git repo root.
+#
+# Motivation: VERSION/CHANGELOG merge conflicts recurred across 4+ sessions;
+# the durable fix is per-run dated fragment files assembled by a release job.
+# This hook surfaces the policy ONCE as a permission prompt ("ask") instead of
+# hard-denying, so a legitimately-authorized edit is one approval away and
+# nothing loops around the gate.
+#
+# Bypass for repos where direct edits are fine: CLAUDE_ALLOW_SHARED_FILE_EDITS=1
+
+[ "$CLAUDE_ALLOW_SHARED_FILE_EDITS" = "1" ] && exit 0
+
+JQ=/opt/homebrew/bin/jq
+[ -x "$JQ" ] || JQ=jq
+
+FILE=$("$JQ" -r '.tool_input.file_path // empty' 2>/dev/null)
+[ -n "$FILE" ] || exit 0
+
+base=$(basename "$FILE")
+case "$base" in
+  VERSION|CHANGELOG.md|hot.md) ;;
+  *) exit 0 ;;
+esac
+
+# Only guard files at a git repo root (VERSION elsewhere is fair game)
+dir=$(dirname "$FILE")
+if git -C "$dir" rev-parse --show-toplevel >/dev/null 2>&1; then
+  top=$(git -C "$dir" rev-parse --show-toplevel)
+  if [ "$dir" = "$top" ] || [[ "$FILE" == */wiki/hot.md ]]; then
+    "$JQ" -n --arg f "$base" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: ("Shared-file conflict policy: " + $f + " is a known merge-conflict magnet. Prefer a per-run dated fragment file assembled by the release job. Approve only if a direct edit is genuinely intended.")
+      }
+    }'
+    exit 0
+  fi
+fi
+exit 0

--- a/infra/claude/install.sh
+++ b/infra/claude/install.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Install the cluster-wide Claude hardening (hooks, skills, global rules) on this node.
+# Idempotent — safe to re-run after every `git -C ~/factorylm pull`.
+#
+# What it does:
+#   1. Copies hooks into ~/.claude/hooks/ and skills into ~/.claude/skills/
+#   2. Merges the three hook registrations into ~/.claude/settings.json
+#      (only if a hook entry with the same command isn't already present)
+#   3. Ensures ~/.claude/CLAUDE.md imports infra/claude/CLAUDE-GLOBAL-RULES.md
+#
+# Provenance: docs/insights/README.md
+set -euo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)"
+case "$SRC" in
+  */worktrees/*)
+    echo "ERROR: running from a temporary worktree ($SRC)." >&2
+    echo "The CLAUDE.md import would dangle when the worktree is removed." >&2
+    echo "Run from the main checkout instead: bash ~/factorylm/infra/claude/install.sh" >&2
+    exit 1 ;;
+esac
+CLAUDE_DIR="$HOME/.claude"
+mkdir -p "$CLAUDE_DIR/hooks" "$CLAUDE_DIR/skills/resume"
+
+# 1. Hooks + skills
+cp "$SRC/hooks/"*.sh "$CLAUDE_DIR/hooks/"
+chmod +x "$CLAUDE_DIR/hooks/"*.sh
+cp "$SRC/skills/resume/SKILL.md" "$CLAUDE_DIR/skills/resume/SKILL.md"
+cp "$SRC/skills/ship.md" "$CLAUDE_DIR/skills/ship.md"
+echo "installed: hooks (reap-orphaned-lsp, shared-file-guard, ruff-on-edit), skills (/resume, /ship)"
+
+# 2. settings.json hook registration (python3 stdlib; system 3.9 is fine)
+SETTINGS="$CLAUDE_DIR/settings.json" python3 - <<'PYEOF'
+import json, os
+
+path = os.environ["SETTINGS"]
+home = os.path.expanduser("~")
+try:
+    with open(path) as f:
+        settings = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    settings = {}
+
+hooks = settings.setdefault("hooks", {})
+
+def has_command(event, needle):
+    for group in hooks.get(event, []):
+        for h in group.get("hooks", []):
+            if needle in h.get("command", ""):
+                return True
+    return False
+
+def add(event, matcher, command, timeout):
+    if has_command(event, os.path.basename(command.split()[-1])):
+        return False
+    group = {"hooks": [{"type": "command", "command": command, "timeout": timeout}]}
+    if matcher:
+        group["matcher"] = matcher
+    hooks.setdefault(event, []).append(group)
+    return True
+
+changed = False
+changed |= add("SessionStart", None,
+               "bash %s/.claude/hooks/reap-orphaned-lsp.sh" % home, 15)
+changed |= add("PreToolUse", "Edit|Write",
+               "bash %s/.claude/hooks/shared-file-guard.sh" % home, 10)
+changed |= add("PostToolUse", "Edit|Write",
+               "bash %s/.claude/hooks/ruff-on-edit.sh" % home, 30)
+
+if changed:
+    with open(path, "w") as f:
+        json.dump(settings, f, indent=2)
+        f.write("\n")
+    print("settings.json: hook registrations added")
+else:
+    print("settings.json: hooks already registered")
+PYEOF
+
+# 3. Global rules import in ~/.claude/CLAUDE.md
+RULES="$SRC/CLAUDE-GLOBAL-RULES.md"
+CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
+touch "$CLAUDE_MD"
+if grep -qF "CLAUDE-GLOBAL-RULES.md" "$CLAUDE_MD"; then
+  echo "CLAUDE.md: global rules import already present"
+else
+  printf '\n## Cluster-wide Claude Rules (insights-derived)\n\n@%s\n' "$RULES" >> "$CLAUDE_MD"
+  echo "CLAUDE.md: added import of $RULES"
+fi
+
+echo "done. New sessions pick everything up automatically; running sessions need /hooks or a restart."

--- a/infra/claude/skills/resume/SKILL.md
+++ b/infra/claude/skills/resume/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: resume
+description: Safely resume from a handoff doc or continue a workstream without duplicating work a parallel session already landed. Use when a session starts from a handoff pointer, "continue where we left off", or resuming any multi-session program. Reconciles handoff claims against actual repo state BEFORE any work starts.
+---
+
+# /resume — Reconcile Before You Work
+
+Handoffs go stale and parallel sessions land work. A session once rebuilt two already-merged PRs and burned most of its budget before the user interrupted. Never start from the handoff's word — start from the repo's.
+
+## Step 1: Read the handoff
+
+Read the handoff doc (argument, or most recent in the usual handoff location). Extract every claim into a checklist: PR numbers, branches, SHAs, "open"/"merged"/"blocked" states, next actions.
+
+## Step 2: Fetch reality
+
+```bash
+git fetch --all --prune
+git log --oneline origin/main -30
+gh pr list --state all --limit 30 --json number,title,state,mergedAt,headRefName
+gh pr list --state all --search "updated:>=$(date -v-2d +%Y-%m-%d)" --json number,title,state
+```
+
+Also check for other live sessions/worktrees that might be mid-flight:
+
+```bash
+git worktree list
+```
+
+## Step 3: Diff claims vs reality
+
+For each handoff claim, mark: **confirmed** / **already done elsewhere** / **stale** / **contradicted**. Anything already merged or closed comes OFF the work list. Anything contradicted gets re-verified from the artifact (PR body, CI run, diff), not from the handoff prose.
+
+## Step 4: Preflight the environment
+
+Long runs die on avoidable stalls. Check before starting, not mid-flight:
+
+```bash
+gh auth status
+docker info >/dev/null 2>&1 || echo "Colima/Docker down"
+```
+
+Plus any services the work needs (Qdrant :8000, PLC API :8001, etc. — see project CLAUDE.md).
+
+## Step 5: Report, then work
+
+Output a short table — item, source claim, verified state, action — then execute ONLY the surviving items. Do not Edit/Write anything before Step 5.

--- a/infra/claude/skills/ship.md
+++ b/infra/claude/skills/ship.md
@@ -1,0 +1,81 @@
+---
+name: ship
+description: Merge-and-deploy run-book. Use when merging a PR and deploying to VPS. Encodes the full checklist: CI gate → merge → deploy → verify → Linear update. Trigger on "ship PR", "merge and deploy", "deploy this", "ship it".
+---
+
+# /ship — Merge & Deploy Run-book
+
+## Step 1: CI Gate (SHA-pinned — a badge is not proof)
+
+```bash
+gh pr view <PR_NUMBER> --json headRefOid,mergeable,statusCheckRollup
+```
+
+- **Pin the SHA**: the green check runs must report against `headRefOid` (the PR's *current* head). A green run for a previous head is NOT green — push/wait and re-check.
+- All required checks `success` — `skipped`/`neutral` on a required check counts as a failure; investigate why it skipped.
+- **If this PR adds tests**: confirm they actually executed — grep the CI run log for the new test names (`gh run view <run-id> --log | grep <test_name>`). Also grep for `ModuleNotFoundError` and `command not found`; workflows have silently no-opped on missing deps.
+- If checks are failing: compare against main head (`gh run list --branch main --limit 3`).
+  - **Pre-existing on main** (unrelated to this PR) → confirm with user, then proceed.
+  - **New failure** → STOP. Do not merge. Fix or escalate.
+
+## Step 1.5: Hazard Ledger
+
+Before merging, list every hazard/TODO/"probably fine" noticed during the work but not fixed. Each gets a disposition: `fixed | filed as issue #N | explicitly accepted because <reason>`. A non-empty list with no dispositions = do not merge; report it instead.
+
+## Step 2: Dependency Order
+
+Check if this PR depends on another unmerged PR (look at description, imports, migration files). Merge dependencies first.
+
+## Step 3: Merge
+
+```bash
+gh pr merge <PR_NUMBER> --squash --auto
+```
+
+Or if auto-merge is blocked:
+```bash
+gh pr merge <PR_NUMBER> --squash
+```
+
+## Step 4: Deploy to VPS
+
+```bash
+doppler run --project factorylm --config prd -- docker compose pull <service>
+doppler run --project factorylm --config prd -- docker compose up -d <service>
+```
+
+Or full stack:
+```bash
+doppler run --project factorylm --config prd -- docker compose up -d
+```
+
+## Step 5: Verify
+
+Run smoke tests against affected routes:
+```bash
+bash install/smoke_test.sh
+```
+
+Or targeted Playwright:
+```bash
+npx playwright test --grep "<feature>"
+```
+
+Report: status codes, screenshots to `docs/promo-screenshots/` (both 1440x900 and 412x915), any errors in `docker compose logs -f <service> --tail=50`.
+
+**Behavioral diff for feature PRs**: capture the observable output of the affected endpoint BEFORE deploying and AFTER. If they are identical, that is a FAILURE, not a pass — a feature once shipped into a dead staging layer and "worked" while changing nothing. Trace the request path until you find where it diverges from expectation.
+
+**STOP if smoke fails** — rollback: `docker compose up -d --scale <service>=0` then re-deploy prior image.
+
+## Step 6: Update Linear
+
+Find the linked Linear ticket and move to **Done**:
+- Add PR link as attachment
+- Note deploy timestamp and verification result
+
+## Checkpoints (STOP and ask if)
+
+- New red CI check (not pre-existing)
+- Smoke test failure post-deploy
+- Migration detected but not verified applied
+- PR touches `SAFETY`, `PLC`, or `CRITICAL` tagged code

--- a/scripts/agent_claim.py
+++ b/scripts/agent_claim.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""
+agent_claim.py — Lease/claim management system to prevent duplicate work.
+
+Leases live in .agents/leases/<item-slug>.json with structure:
+  {agent_id, item, worktree, branch, started_at, heartbeat_at, status}
+
+Subcommands:
+  claim <item> [--agent-id X] [--worktree P] [--branch B] [--stale-hours N] [--no-preflight]
+  heartbeat <item>
+  release <item> [--status merged|abandoned]
+  census [--reap]
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+
+def slugify(item: str) -> str:
+    """Convert item name to a safe filename slug."""
+    # Replace non-alphanumeric with hyphen
+    slug = re.sub(r"[^a-z0-9]+", "-", item.lower()).strip("-")
+    return slug
+
+
+def get_lease_path(item: str, leases_dir: str = ".agents/leases") -> Path:
+    """Get the lease file path for an item."""
+    return Path(leases_dir) / f"{slugify(item)}.json"
+
+
+def read_lease(item: str, leases_dir: str = ".agents/leases") -> Optional[Dict]:
+    """Read lease file if it exists."""
+    lease_path = get_lease_path(item, leases_dir)
+    if not lease_path.exists():
+        return None
+    with open(lease_path, "r") as f:
+        return json.load(f)
+
+
+def write_lease(
+    item: str, lease_data: Dict, leases_dir: str = ".agents/leases"
+) -> None:
+    """Write lease file (non-atomic)."""
+    Path(leases_dir).mkdir(parents=True, exist_ok=True)
+    lease_path = get_lease_path(item, leases_dir)
+    with open(lease_path, "w") as f:
+        json.dump(lease_data, f, indent=2)
+
+
+def atomic_create_lease(
+    item: str, lease_data: Dict, leases_dir: str = ".agents/leases"
+) -> bool:
+    """
+    Atomically create a lease file using O_CREAT|O_EXCL.
+    Returns True if created, False if file already exists.
+    """
+    Path(leases_dir).mkdir(parents=True, exist_ok=True)
+    lease_path = get_lease_path(item, leases_dir)
+    try:
+        # O_CREAT|O_EXCL fails if file exists
+        fd = os.open(str(lease_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        with os.fdopen(fd, "w") as f:
+            json.dump(lease_data, f, indent=2)
+        return True
+    except FileExistsError:
+        return False
+
+
+def is_stale(heartbeat_at: str, stale_hours: int = 4) -> bool:
+    """
+    Check if a heartbeat timestamp is older than stale_hours.
+    heartbeat_at should be UTC ISO-8601 string.
+    """
+    try:
+        hb_time = datetime.fromisoformat(heartbeat_at.replace("Z", "+00:00"))
+        now = datetime.now(timezone.utc)
+        age = now - hb_time
+        return age > timedelta(hours=stale_hours)
+    except (ValueError, AttributeError):
+        return True
+
+
+def run_preflight_check(item: str, repo: Optional[str] = None) -> Optional[str]:
+    """
+    Check if work already appears merged.
+    Run: gh pr list --state all --search <item>
+         git log --all --grep=<item> --oneline
+    Returns error message if work already done, None if clear.
+    """
+    try:
+        # Check PRs
+        cmd = ["gh", "pr", "list", "--state", "all", "--search", item]
+        if repo:
+            cmd.extend(["-R", repo])
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            # Found matching PRs
+            return f"Work already has matching PR(s): {result.stdout.split()[0] if result.stdout else item}"
+
+        # Check git log
+        cmd = ["git", "log", "--all", "--grep", item, "--oneline"]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+        if result.returncode == 0 and result.stdout.strip():
+            return f"Work already committed: {result.stdout.split()[0] if result.stdout else item}"
+    except subprocess.TimeoutExpired:
+        pass  # If gh/git timeout, allow claim (offline mode)
+    except Exception:
+        pass  # Preflight errors are non-fatal
+
+    return None
+
+
+def cmd_claim(
+    item: str,
+    agent_id: str = "claude",
+    worktree: str = ".",
+    branch: str = "main",
+    stale_hours: int = 4,
+    no_preflight: bool = False,
+    repo: Optional[str] = None,
+) -> int:
+    """
+    Claim an item. Exit 0 on success, 1 on fresh lease conflict, 2 on already-merged.
+    """
+    # Preflight check
+    if not no_preflight:
+        preflight_err = run_preflight_check(item, repo)
+        if preflight_err:
+            print(f"PREFLIGHT FAIL: {preflight_err}", file=sys.stderr)
+            return 2
+
+    # Check for existing lease
+    existing = read_lease(item)
+    if existing:
+        hb = existing.get("heartbeat_at", "")
+        if not is_stale(hb, stale_hours):
+            print(
+                f"CLAIM FAIL: fresh lease exists (heartbeat: {hb})",
+                file=sys.stderr,
+            )
+            return 1
+        else:
+            # Lease is stale, remove it before claiming
+            get_lease_path(item).unlink(missing_ok=True)
+
+    # Try atomic create
+    now = datetime.now(timezone.utc).isoformat()
+    lease_data = {
+        "agent_id": agent_id,
+        "item": item,
+        "worktree": worktree,
+        "branch": branch,
+        "started_at": now,
+        "heartbeat_at": now,
+        "status": "in_progress",
+    }
+
+    if atomic_create_lease(item, lease_data):
+        print(json.dumps(lease_data, indent=2))
+        return 0
+    else:
+        print("CLAIM FAIL: file exists (race condition)", file=sys.stderr)
+        return 1
+
+
+def cmd_heartbeat(item: str) -> int:
+    """
+    Update heartbeat timestamp. Exit 0 on success, 1 if lease doesn't exist.
+    """
+    existing = read_lease(item)
+    if not existing:
+        print(f"HEARTBEAT FAIL: no lease for {item}", file=sys.stderr)
+        return 1
+
+    existing["heartbeat_at"] = datetime.now(timezone.utc).isoformat()
+    write_lease(item, existing)
+    print(json.dumps(existing, indent=2))
+    return 0
+
+
+def cmd_release(item: str, status: str = "merged") -> int:
+    """
+    Release a lease. Exit 0 on success, 1 if lease doesn't exist.
+    Appends one line to .agents/leases/HISTORY.log.
+    """
+    existing = read_lease(item)
+    if not existing:
+        print(f"RELEASE FAIL: no lease for {item}", file=sys.stderr)
+        return 1
+
+    # Remove lease file
+    lease_path = get_lease_path(item)
+    lease_path.unlink(missing_ok=True)
+
+    # Append to history log
+    Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+    history_path = Path(".agents/leases/HISTORY.log")
+    timestamp = datetime.now(timezone.utc).isoformat()
+    log_line = f"{timestamp} | {item} | status={status} | agent_id={existing.get('agent_id', 'unknown')}\n"
+    with open(history_path, "a") as f:
+        f.write(log_line)
+
+    print(f"RELEASED: {item} ({status})")
+    return 0
+
+
+def cmd_census(reap: bool = False) -> int:
+    """
+    Show table of live vs stale leases.
+    If --reap, delete stale leases.
+    """
+    leases_dir = Path(".agents/leases")
+    if not leases_dir.exists():
+        print("No leases found")
+        return 0
+
+    leases = [f for f in leases_dir.glob("*.json") if f.name != "HISTORY.log"]
+
+    if not leases:
+        print("No active leases")
+        return 0
+
+    live = []
+    stale = []
+    for lease_file in leases:
+        with open(lease_file, "r") as f:
+            lease_data = json.load(f)
+        hb = lease_data.get("heartbeat_at", "")
+        item_name = lease_file.stem
+        if is_stale(hb, 4):
+            stale.append((item_name, lease_file, lease_data))
+        else:
+            live.append((item_name, lease_file, lease_data))
+
+    print(f"LIVE LEASES ({len(live)}):")
+    for item_name, _, data in live:
+        print(
+            f"  {item_name}: {data.get('agent_id')} @ {data.get('branch')} (hb: {data.get('heartbeat_at')})"
+        )
+
+    print(f"\nSTALE LEASES ({len(stale)}):")
+    for item_name, _, data in stale:
+        print(
+            f"  {item_name}: {data.get('agent_id')} @ {data.get('branch')} (hb: {data.get('heartbeat_at')})"
+        )
+
+    if reap:
+        for _, lease_file, _ in stale:
+            lease_file.unlink(missing_ok=True)
+        print(f"\nREAPED {len(stale)} stale lease(s)")
+
+    return 0
+
+
+def main():
+    """Parse CLI and dispatch subcommands."""
+    if len(sys.argv) < 2:
+        print("Usage: agent_claim.py <subcommand> [args]")
+        print(
+            "  claim <item> [--agent-id X] [--worktree P] [--branch B] [--stale-hours N] [--no-preflight]"
+        )
+        print("  heartbeat <item>")
+        print("  release <item> [--status merged|abandoned]")
+        print("  census [--reap]")
+        sys.exit(1)
+
+    subcommand = sys.argv[1]
+
+    if subcommand == "claim":
+        if len(sys.argv) < 3:
+            print("Usage: agent_claim.py claim <item> [options]")
+            sys.exit(1)
+        item = sys.argv[2]
+
+        agent_id = "claude"
+        if "--agent-id" in sys.argv:
+            idx = sys.argv.index("--agent-id")
+            if idx + 1 < len(sys.argv):
+                agent_id = sys.argv[idx + 1]
+
+        worktree = "."
+        if "--worktree" in sys.argv:
+            idx = sys.argv.index("--worktree")
+            if idx + 1 < len(sys.argv):
+                worktree = sys.argv[idx + 1]
+
+        branch = "main"
+        if "--branch" in sys.argv:
+            idx = sys.argv.index("--branch")
+            if idx + 1 < len(sys.argv):
+                branch = sys.argv[idx + 1]
+
+        stale_hours = 4
+        if "--stale-hours" in sys.argv:
+            idx = sys.argv.index("--stale-hours")
+            if idx + 1 < len(sys.argv):
+                try:
+                    stale_hours = int(sys.argv[idx + 1])
+                except ValueError:
+                    print("Invalid --stale-hours value")
+                    sys.exit(1)
+
+        no_preflight = "--no-preflight" in sys.argv
+
+        sys.exit(cmd_claim(item, agent_id, worktree, branch, stale_hours, no_preflight))
+
+    elif subcommand == "heartbeat":
+        if len(sys.argv) < 3:
+            print("Usage: agent_claim.py heartbeat <item>")
+            sys.exit(1)
+        item = sys.argv[2]
+        sys.exit(cmd_heartbeat(item))
+
+    elif subcommand == "release":
+        if len(sys.argv) < 3:
+            print("Usage: agent_claim.py release <item> [--status merged|abandoned]")
+            sys.exit(1)
+        item = sys.argv[2]
+        status = "merged"
+        if "--status" in sys.argv:
+            idx = sys.argv.index("--status")
+            if idx + 1 < len(sys.argv):
+                status = sys.argv[idx + 1]
+        sys.exit(cmd_release(item, status))
+
+    elif subcommand == "census":
+        reap = "--reap" in sys.argv
+        sys.exit(cmd_census(reap))
+
+    else:
+        print(f"Unknown subcommand: {subcommand}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_green.py
+++ b/scripts/verify_green.py
@@ -62,7 +62,9 @@ def scan_logs_for_errors(log_text: str) -> List[str]:
     Returns list of error messages found (empty if clean).
     """
     errors = []
-    if "ModuleNotFoundError" in log_text:
+    # Colon required: a real traceback is always "ModuleNotFoundError: ...";
+    # bare mentions occur legitimately (e.g. commit messages echoed into logs).
+    if "ModuleNotFoundError:" in log_text:
         errors.append("ModuleNotFoundError found in logs")
     if "command not found" in log_text:
         errors.append("command not found error in logs")

--- a/scripts/verify_green.py
+++ b/scripts/verify_green.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+verify_green.py — Verify that a PR's CI checks are truly green.
+
+Exit 0 only if:
+  1. Newest check-run set reports against PR's current head SHA
+  2. All required checks concluded with 'success' (fail on skipped/neutral/cancelled)
+  3. If PR diff adds test functions, each test appears in CI logs
+  4. Logs contain no ModuleNotFoundError or command not found errors
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+def compare_sha(actual: str, expected: str) -> bool:
+    """Return True if SHAs match (same commit)."""
+    return actual.strip() == expected.strip()
+
+
+def classify_conclusion(conclusion: str) -> Tuple[bool, str]:
+    """
+    Classify a check conclusion.
+    Returns (is_success, reason).
+    Only 'success' is acceptable; others fail with a reason.
+    """
+    conclusion = conclusion.strip().lower()
+    if conclusion == "success":
+        return True, "success"
+    elif conclusion == "skipped":
+        return False, "check was skipped"
+    elif conclusion == "neutral":
+        return False, "check was neutral"
+    elif conclusion == "cancelled":
+        return False, "check was cancelled"
+    else:
+        return False, f"unexpected conclusion: {conclusion}"
+
+
+def extract_new_tests(diff_text: str) -> List[str]:
+    """
+    Extract new test function names from a PR diff.
+    Regex: lines starting with '+' followed by 'def test_'.
+    Returns list of test function names (without 'def ' prefix).
+    """
+    tests = []
+    for line in diff_text.split("\n"):
+        # Match: +<optional-whitespace>def test_<name>
+        match = re.match(r"^\+\s*def\s+(test_\w+)", line)
+        if match:
+            tests.append(match.group(1))
+    return tests
+
+
+def scan_logs_for_errors(log_text: str) -> List[str]:
+    """
+    Scan logs for known error patterns.
+    Returns list of error messages found (empty if clean).
+    """
+    errors = []
+    if "ModuleNotFoundError" in log_text:
+        errors.append("ModuleNotFoundError found in logs")
+    if "command not found" in log_text:
+        errors.append("command not found error in logs")
+    return errors
+
+
+def run_cmd(cmd: List[str]) -> str:
+    """
+    Run a shell command and return stdout.
+    Raises subprocess.CalledProcessError on non-zero exit.
+    """
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        )
+    return result.stdout
+
+
+def get_pr_head_sha(pr_number: int, repo: Optional[str] = None) -> str:
+    """Get the current head SHA of a PR via 'gh pr view --json headRefOid'."""
+    cmd = ["gh", "pr", "view", str(pr_number), "--json", "headRefOid"]
+    if repo:
+        cmd.extend(["-R", repo])
+    output = run_cmd(cmd)
+    data = json.loads(output)
+    return data.get("headRefOid", "")
+
+
+def get_pr_diff(pr_number: int, repo: Optional[str] = None) -> str:
+    """Get the PR diff via 'gh pr diff'."""
+    cmd = ["gh", "pr", "diff", str(pr_number)]
+    if repo:
+        cmd.extend(["-R", repo])
+    return run_cmd(cmd)
+
+
+def get_repo_slug(repo: Optional[str] = None) -> str:
+    """Resolve owner/name, defaulting to the current directory's repo."""
+    if repo:
+        return repo
+    output = run_cmd(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"]
+    )
+    return output.strip()
+
+
+def get_check_runs_for_sha(sha: str, repo: Optional[str] = None) -> List[Dict]:
+    """
+    Get check-runs reported against EXACTLY this commit SHA via the REST API.
+    Inherently SHA-pinned: a green badge from a previous head cannot appear here.
+    Returns list of {name, status, conclusion, completed_at}.
+    """
+    slug = get_repo_slug(repo)
+    output = run_cmd(
+        ["gh", "api", "repos/%s/commits/%s/check-runs" % (slug, sha), "--paginate"]
+    )
+    check_runs: List[Dict] = []
+    # --paginate concatenates JSON objects; parse each document
+    decoder = json.JSONDecoder()
+    idx = 0
+    text = output.strip()
+    while idx < len(text):
+        obj, end = decoder.raw_decode(text, idx)
+        check_runs.extend(obj.get("check_runs", []))
+        idx = end
+        while idx < len(text) and text[idx] in " \n\r\t":
+            idx += 1
+    return check_runs
+
+
+def get_run_ids_for_sha(sha: str, repo: Optional[str] = None) -> List[str]:
+    """Get workflow-run IDs whose headSha is exactly this SHA."""
+    cmd = [
+        "gh",
+        "run",
+        "list",
+        "--commit",
+        sha,
+        "--json",
+        "databaseId,status,headSha",
+        "--limit",
+        "50",
+    ]
+    if repo:
+        cmd.extend(["-R", repo])
+    runs = json.loads(run_cmd(cmd))
+    return [
+        str(r["databaseId"])
+        for r in runs
+        if r.get("headSha") == sha and r.get("status") == "completed"
+    ]
+
+
+def get_run_logs(run_id: str, repo: Optional[str] = None) -> str:
+    """Get logs from a specific workflow run via 'gh run view --log'."""
+    cmd = ["gh", "run", "view", run_id, "--log"]
+    if repo:
+        cmd.extend(["-R", repo])
+    return run_cmd(cmd)
+
+
+def verify_green(pr_number: int, repo: Optional[str] = None) -> Dict:
+    """
+    Main verification logic.
+    Returns dict: {pr, sha, checks, tests_added, tests_found_in_log, verdict, errors}
+    """
+    verdict = {
+        "pr": pr_number,
+        "sha": "",
+        "checks": [],
+        "tests_added": [],
+        "tests_found_in_log": [],
+        "errors": [],
+    }
+
+    try:
+        # Get current head SHA
+        head_sha = get_pr_head_sha(pr_number, repo)
+        verdict["sha"] = head_sha
+        if not head_sha:
+            verdict["errors"].append("Could not resolve PR head SHA")
+            return verdict
+
+        # Check 1 (SHA pinning): fetch check-runs for EXACTLY the current head.
+        # A green badge from a previous head simply cannot appear in this list;
+        # an empty list means CI never reported against the current head.
+        checks = get_check_runs_for_sha(head_sha, repo)
+        if not checks:
+            verdict["errors"].append(
+                f"No check-runs reported against current head {head_sha[:8]} "
+                "— any green badge you saw belongs to a previous head"
+            )
+            return verdict
+
+        # Check 2: every check-run must be completed AND concluded success
+        check_list = []
+        for check in checks:
+            name = check.get("name", "unknown")
+            status = check.get("status", "")
+            conclusion = check.get("conclusion") or ""
+            check_list.append({"name": name, "conclusion": conclusion})
+            if status != "completed":
+                verdict["errors"].append(
+                    f"Check '{name}': still '{status}', not completed"
+                )
+                continue
+            is_success, reason = classify_conclusion(conclusion)
+            if not is_success:
+                verdict["errors"].append(f"Check '{name}': {reason}")
+
+        verdict["checks"] = check_list
+
+        # Get diff and extract new tests
+        diff_text = get_pr_diff(pr_number, repo)
+        new_tests = extract_new_tests(diff_text)
+        verdict["tests_added"] = new_tests
+
+        # Check 3+4: fetch logs of all completed runs for this SHA; new tests
+        # must appear, and no silent no-op markers may appear.
+        try:
+            run_ids = get_run_ids_for_sha(head_sha, repo)
+            logs = "\n".join(get_run_logs(rid, repo) for rid in run_ids)
+            if not logs:
+                verdict["errors"].append(
+                    f"No workflow-run logs found for head {head_sha[:8]}"
+                )
+            log_errors = scan_logs_for_errors(logs)
+            verdict["errors"].extend(log_errors)
+
+            found_in_log = []
+            for test in new_tests:
+                if test in logs:
+                    found_in_log.append(test)
+                else:
+                    verdict["errors"].append(f"Test '{test}' not found in CI logs")
+            verdict["tests_found_in_log"] = found_in_log
+        except subprocess.CalledProcessError as e:
+            verdict["errors"].append(f"Could not fetch logs: {e}")
+
+    except subprocess.CalledProcessError as e:
+        verdict["errors"].append(f"Command failed: {e}")
+    except json.JSONDecodeError as e:
+        verdict["errors"].append(f"JSON parse error: {e}")
+    except Exception as e:
+        verdict["errors"].append(f"Unexpected error: {e}")
+
+    return verdict
+
+
+def save_verdict(verdict: Dict, output_dir: str = ".verify_green") -> None:
+    """Save verdict JSON to file."""
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+    pr = verdict.get("pr", "unknown")
+    sha = verdict.get("sha", "unknown")[:8]
+    filename = Path(output_dir) / f"{pr}-{sha}.json"
+    with open(filename, "w") as f:
+        json.dump(verdict, f, indent=2)
+
+
+def run_self_test() -> bool:
+    """
+    Run offline unit checks on pure functions.
+    Returns True if all pass.
+    """
+    tests_passed = 0
+    tests_failed = 0
+
+    # Test: compare_sha
+    if compare_sha("abc123", "abc123"):
+        tests_passed += 1
+    else:
+        print("FAIL: compare_sha identical")
+        tests_failed += 1
+
+    if not compare_sha("abc123", "def456"):
+        tests_passed += 1
+    else:
+        print("FAIL: compare_sha different")
+        tests_failed += 1
+
+    # Test: classify_conclusion
+    is_ok, _ = classify_conclusion("success")
+    if is_ok:
+        tests_passed += 1
+    else:
+        print("FAIL: classify_conclusion success")
+        tests_failed += 1
+
+    is_ok, _ = classify_conclusion("skipped")
+    if not is_ok:
+        tests_passed += 1
+    else:
+        print("FAIL: classify_conclusion skipped")
+        tests_failed += 1
+
+    # Test: extract_new_tests
+    diff = "line1\n+  def test_foo():\n+    pass\nline2\n+def test_bar():"
+    tests = extract_new_tests(diff)
+    if tests == ["test_foo", "test_bar"]:
+        tests_passed += 1
+    else:
+        print(f"FAIL: extract_new_tests got {tests}")
+        tests_failed += 1
+
+    # Test: scan_logs_for_errors
+    log_clean = "All tests passed"
+    errors = scan_logs_for_errors(log_clean)
+    if not errors:
+        tests_passed += 1
+    else:
+        print("FAIL: scan_logs_for_errors clean log")
+        tests_failed += 1
+
+    log_error = "ModuleNotFoundError: no module named foo"
+    errors = scan_logs_for_errors(log_error)
+    if errors and "ModuleNotFoundError" in errors[0]:
+        tests_passed += 1
+    else:
+        print("FAIL: scan_logs_for_errors ModuleNotFoundError")
+        tests_failed += 1
+
+    return tests_failed == 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: verify_green.py <pr-number> [--repo owner/name] [--self-test]")
+        sys.exit(1)
+
+    if sys.argv[1] == "--self-test":
+        if run_self_test():
+            print("PASS")
+            sys.exit(0)
+        else:
+            print("FAIL")
+            sys.exit(1)
+
+    try:
+        pr_num = int(sys.argv[1])
+    except ValueError:
+        print(f"Invalid PR number: {sys.argv[1]}")
+        sys.exit(1)
+
+    repo = None
+    if "--repo" in sys.argv:
+        idx = sys.argv.index("--repo")
+        if idx + 1 < len(sys.argv):
+            repo = sys.argv[idx + 1]
+
+    verdict = verify_green(pr_num, repo)
+    save_verdict(verdict)
+
+    if verdict.get("errors"):
+        print(json.dumps(verdict, indent=2))
+        sys.exit(1)
+    else:
+        print(json.dumps(verdict, indent=2))
+        sys.exit(0)

--- a/tests/test_agent_claim.py
+++ b/tests/test_agent_claim.py
@@ -1,0 +1,353 @@
+"""
+Tests for agent_claim.py — lease management, race conditions, staleness.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from agent_claim import (
+    atomic_create_lease,
+    cmd_claim,
+    cmd_census,
+    cmd_heartbeat,
+    cmd_release,
+    is_stale,
+    read_lease,
+    slugify,
+    write_lease,
+)
+
+
+class TestSlugify:
+    """Test slug generation."""
+
+    def test_lowercase(self):
+        assert slugify("MyItem") == "myitem"
+
+    def test_spaces_to_hyphens(self):
+        assert slugify("My Item") == "my-item"
+
+    def test_special_chars_stripped(self):
+        assert slugify("my-item@v1") == "my-item-v1"
+
+
+class TestIsStale:
+    """Test staleness detection."""
+
+    def test_fresh_heartbeat(self):
+        now = datetime.now(timezone.utc).isoformat()
+        assert not is_stale(now, 4)
+
+    def test_stale_heartbeat(self):
+        old = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+        assert is_stale(old, 4)
+
+    def test_exactly_at_boundary(self):
+        # Exactly 4 hours old should not be stale
+        boundary = (datetime.now(timezone.utc) - timedelta(hours=4)).isoformat()
+        result = is_stale(boundary, 4)
+        # Could be true or false depending on seconds, so we just check it's close
+        assert isinstance(result, bool)
+
+    def test_invalid_timestamp(self):
+        assert is_stale("not-a-timestamp", 4)
+
+
+class TestAtomicCreateLease:
+    """Test atomic lease creation with O_CREAT|O_EXCL."""
+
+    def test_creates_new_lease(self, tmp_path):
+        """Test successful lease creation."""
+        leases_dir = tmp_path / "leases"
+        lease_data = {"agent_id": "test", "item": "item1", "status": "in_progress"}
+        result = atomic_create_lease("item1", lease_data, str(leases_dir))
+        assert result is True
+        assert (leases_dir / "item1.json").exists()
+
+    def test_fails_on_existing_lease(self, tmp_path):
+        """Test atomic create fails if lease exists."""
+        leases_dir = tmp_path / "leases"
+        lease_data = {"agent_id": "test", "item": "item1"}
+        atomic_create_lease("item1", lease_data, str(leases_dir))
+
+        # Try to create again
+        result = atomic_create_lease("item1", lease_data, str(leases_dir))
+        assert result is False
+
+    def test_race_condition_exactly_one_wins(self, tmp_path):
+        """Test that exactly one racer wins in a race."""
+        leases_dir = tmp_path / "leases"
+        lease_data = {"agent_id": "test", "item": "race_item"}
+
+        results = []
+        for i in range(2):
+            result = atomic_create_lease("race_item", lease_data, str(leases_dir))
+            results.append(result)
+
+        # Exactly one should succeed
+        assert sum(results) == 1
+
+
+class TestReadWriteLease:
+    """Test lease file I/O."""
+
+    def test_read_nonexistent_lease(self, tmp_path):
+        """Reading nonexistent lease returns None."""
+        result = read_lease("nonexistent", str(tmp_path / "leases"))
+        assert result is None
+
+    def test_write_and_read_lease(self, tmp_path):
+        """Write and read roundtrip."""
+        leases_dir = str(tmp_path / "leases")
+        lease_data = {"agent_id": "test", "item": "item1", "status": "in_progress"}
+        write_lease("item1", lease_data, leases_dir)
+
+        read_data = read_lease("item1", leases_dir)
+        assert read_data == lease_data
+
+
+class TestCmdClaim:
+    """Test claim subcommand."""
+
+    @patch("agent_claim.run_preflight_check")
+    def test_claim_success(self, mock_preflight, tmp_path):
+        """Test successful claim."""
+        mock_preflight.return_value = None
+        os.chdir(tmp_path)
+
+        result = cmd_claim(
+            "item1",
+            agent_id="agent-1",
+            worktree=str(tmp_path),
+            branch="feat/test",
+            no_preflight=False,
+        )
+        assert result == 0
+        assert (tmp_path / ".agents/leases/item1.json").exists()
+
+    @patch("agent_claim.run_preflight_check")
+    def test_claim_already_merged_fails_with_2(self, mock_preflight, tmp_path):
+        """Test claim fails with exit 2 if work already merged."""
+        mock_preflight.return_value = "Work already merged"
+        os.chdir(tmp_path)
+
+        result = cmd_claim("item1", no_preflight=False)
+        assert result == 2
+
+    @patch("agent_claim.run_preflight_check")
+    def test_claim_fresh_lease_fails_with_1(self, mock_preflight, tmp_path):
+        """Test claim fails with exit 1 if fresh lease exists."""
+        mock_preflight.return_value = None
+        os.chdir(tmp_path)
+
+        # Create a fresh lease
+        now = datetime.now(timezone.utc).isoformat()
+        lease_data = {
+            "agent_id": "other",
+            "item": "item1",
+            "started_at": now,
+            "heartbeat_at": now,
+            "status": "in_progress",
+        }
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+        with open(".agents/leases/item1.json", "w") as f:
+            json.dump(lease_data, f)
+
+        result = cmd_claim("item1", no_preflight=False)
+        assert result == 1
+
+    @patch("agent_claim.run_preflight_check")
+    def test_claim_stale_lease_succeeds(self, mock_preflight, tmp_path):
+        """Test claim succeeds if existing lease is stale."""
+        mock_preflight.return_value = None
+        os.chdir(tmp_path)
+
+        # Create a stale lease
+        old = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+        lease_data = {
+            "agent_id": "other",
+            "item": "item1",
+            "started_at": old,
+            "heartbeat_at": old,
+            "status": "in_progress",
+        }
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+        with open(".agents/leases/item1.json", "w") as f:
+            json.dump(lease_data, f)
+
+        result = cmd_claim("item1", stale_hours=4, no_preflight=False)
+        assert result == 0
+
+
+class TestCmdHeartbeat:
+    """Test heartbeat subcommand."""
+
+    def test_heartbeat_success(self, tmp_path):
+        """Test heartbeat updates timestamp."""
+        os.chdir(tmp_path)
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+
+        # Create initial lease
+        lease_data = {
+            "agent_id": "agent-1",
+            "item": "item1",
+            "started_at": "2026-08-23T10:00:00+00:00",
+            "heartbeat_at": "2026-08-23T10:00:00+00:00",
+            "status": "in_progress",
+        }
+        with open(".agents/leases/item1.json", "w") as f:
+            json.dump(lease_data, f)
+
+        result = cmd_heartbeat("item1")
+        assert result == 0
+
+        # Verify heartbeat updated
+        updated = read_lease("item1")
+        assert updated["heartbeat_at"] != lease_data["heartbeat_at"]
+
+    def test_heartbeat_nonexistent_fails(self, tmp_path):
+        """Test heartbeat fails if no lease exists."""
+        os.chdir(tmp_path)
+        result = cmd_heartbeat("nonexistent")
+        assert result == 1
+
+
+class TestCmdRelease:
+    """Test release subcommand."""
+
+    def test_release_success(self, tmp_path):
+        """Test successful release."""
+        os.chdir(tmp_path)
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+
+        # Create lease
+        lease_data = {
+            "agent_id": "agent-1",
+            "item": "item1",
+            "status": "in_progress",
+        }
+        with open(".agents/leases/item1.json", "w") as f:
+            json.dump(lease_data, f)
+
+        result = cmd_release("item1", status="merged")
+        assert result == 0
+        assert not (tmp_path / ".agents/leases/item1.json").exists()
+
+        # Verify history log entry
+        history_path = Path(".agents/leases/HISTORY.log")
+        assert history_path.exists()
+        log_content = history_path.read_text()
+        assert "item1" in log_content
+        assert "merged" in log_content
+
+    def test_release_nonexistent_fails(self, tmp_path):
+        """Test release fails if no lease exists."""
+        os.chdir(tmp_path)
+        result = cmd_release("nonexistent")
+        assert result == 1
+
+
+class TestCmdCensus:
+    """Test census subcommand."""
+
+    def test_census_no_leases(self, tmp_path):
+        """Test census with no leases."""
+        os.chdir(tmp_path)
+        result = cmd_census(reap=False)
+        assert result == 0
+
+    def test_census_live_vs_stale(self, tmp_path):
+        """Test census classifies live vs stale leases."""
+        os.chdir(tmp_path)
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+
+        # Create fresh lease
+        now = datetime.now(timezone.utc).isoformat()
+        fresh_data = {
+            "agent_id": "agent-1",
+            "item": "item1",
+            "started_at": now,
+            "heartbeat_at": now,
+            "status": "in_progress",
+        }
+        with open(".agents/leases/item1.json", "w") as f:
+            json.dump(fresh_data, f)
+
+        # Create stale lease
+        old = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+        stale_data = {
+            "agent_id": "agent-2",
+            "item": "item2",
+            "started_at": old,
+            "heartbeat_at": old,
+            "status": "in_progress",
+        }
+        with open(".agents/leases/item2.json", "w") as f:
+            json.dump(stale_data, f)
+
+        result = cmd_census(reap=False)
+        assert result == 0
+
+        # Both leases should still exist
+        assert Path(".agents/leases/item1.json").exists()
+        assert Path(".agents/leases/item2.json").exists()
+
+    def test_census_reap(self, tmp_path):
+        """Test census --reap deletes stale leases."""
+        os.chdir(tmp_path)
+        Path(".agents/leases").mkdir(parents=True, exist_ok=True)
+
+        # Create stale lease
+        old = (datetime.now(timezone.utc) - timedelta(hours=5)).isoformat()
+        stale_data = {
+            "agent_id": "agent-1",
+            "item": "stale_item",
+            "started_at": old,
+            "heartbeat_at": old,
+            "status": "in_progress",
+        }
+        with open(".agents/leases/stale_item.json", "w") as f:
+            json.dump(stale_data, f)
+
+        result = cmd_census(reap=True)
+        assert result == 0
+        assert not Path(".agents/leases/stale_item.json").exists()
+
+
+class TestClaimReleaseRoundtrip:
+    """Integration test: claim, heartbeat, release."""
+
+    @patch("agent_claim.run_preflight_check")
+    def test_full_workflow(self, mock_preflight, tmp_path):
+        """Test claim -> heartbeat -> release workflow."""
+        mock_preflight.return_value = None
+        os.chdir(tmp_path)
+
+        # Claim
+        result = cmd_claim("feature-123", agent_id="claude-1", no_preflight=False)
+        assert result == 0
+
+        # Verify lease exists
+        lease = read_lease("feature-123")
+        assert lease is not None
+        assert lease["agent_id"] == "claude-1"
+        old_hb = lease["heartbeat_at"]
+
+        # Heartbeat
+        result = cmd_heartbeat("feature-123")
+        assert result == 0
+        lease = read_lease("feature-123")
+        # Heartbeat should be updated (at least the string representation)
+        assert lease["heartbeat_at"] >= old_hb
+
+        # Release
+        result = cmd_release("feature-123", status="merged")
+        assert result == 0
+        assert read_lease("feature-123") is None

--- a/tests/test_verify_green.py
+++ b/tests/test_verify_green.py
@@ -115,6 +115,13 @@ class TestScanLogsForErrors:
         errors = scan_logs_for_errors(logs)
         assert len(errors) >= 2
 
+    def test_bare_mention_without_colon_is_not_an_error(self):
+        # Regression: PR #214's own commit message, echoed into the brain-ingest
+        # log, contains the bare string and must not trip the scanner.
+        logs = "docs: fails on ModuleNotFoundError/command-not-found no-ops\n"
+        errors = scan_logs_for_errors(logs)
+        assert not any("ModuleNotFoundError" in e for e in errors)
+
 
 class TestGetCheckRunsForSha:
     """Test SHA-pinned check-run fetching, incl. --paginate concatenated JSON."""

--- a/tests/test_verify_green.py
+++ b/tests/test_verify_green.py
@@ -1,0 +1,263 @@
+"""
+Tests for verify_green.py — pure functions and mocked subprocess calls.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+# Import the module
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from verify_green import (
+    classify_conclusion,
+    compare_sha,
+    extract_new_tests,
+    get_check_runs_for_sha,
+    get_run_ids_for_sha,
+    scan_logs_for_errors,
+    verify_green,
+)
+
+
+class TestCompareSha:
+    """Test SHA comparison."""
+
+    def test_identical_shas(self):
+        assert compare_sha("abc123", "abc123")
+
+    def test_different_shas(self):
+        assert not compare_sha("abc123", "def456")
+
+    def test_shas_with_whitespace(self):
+        assert compare_sha("abc123\n", "abc123")
+
+
+class TestClassifyConclusion:
+    """Test check conclusion classification."""
+
+    def test_success(self):
+        is_ok, reason = classify_conclusion("success")
+        assert is_ok
+        assert reason == "success"
+
+    def test_skipped(self):
+        is_ok, reason = classify_conclusion("skipped")
+        assert not is_ok
+        assert "skipped" in reason
+
+    def test_neutral(self):
+        is_ok, reason = classify_conclusion("neutral")
+        assert not is_ok
+        assert "neutral" in reason
+
+    def test_cancelled(self):
+        is_ok, reason = classify_conclusion("cancelled")
+        assert not is_ok
+        assert "cancelled" in reason
+
+    def test_unknown(self):
+        is_ok, reason = classify_conclusion("unknown")
+        assert not is_ok
+
+
+class TestExtractNewTests:
+    """Test new test function extraction from diff."""
+
+    def test_no_tests(self):
+        diff = "line1\nline2\n"
+        tests = extract_new_tests(diff)
+        assert tests == []
+
+    def test_single_test(self):
+        diff = "+def test_foo():\n+    pass\n"
+        tests = extract_new_tests(diff)
+        assert "test_foo" in tests
+
+    def test_multiple_tests(self):
+        diff = "+def test_foo():\n+    pass\n+def test_bar():\n+    pass\n"
+        tests = extract_new_tests(diff)
+        assert "test_foo" in tests
+        assert "test_bar" in tests
+
+    def test_indented_tests(self):
+        diff = "+  def test_baz():\n+    pass\n"
+        tests = extract_new_tests(diff)
+        assert "test_baz" in tests
+
+    def test_non_test_functions_ignored(self):
+        diff = "+def helper():\n+    pass\n"
+        tests = extract_new_tests(diff)
+        assert tests == []
+
+
+class TestScanLogsForErrors:
+    """Test error scanning in logs."""
+
+    def test_clean_logs(self):
+        logs = "All tests passed\nBuild successful\n"
+        errors = scan_logs_for_errors(logs)
+        assert errors == []
+
+    def test_module_not_found(self):
+        logs = "ModuleNotFoundError: no module named foo\n"
+        errors = scan_logs_for_errors(logs)
+        assert any("ModuleNotFoundError" in e for e in errors)
+
+    def test_command_not_found(self):
+        logs = "command not found: pytest\n"
+        errors = scan_logs_for_errors(logs)
+        assert any("command not found" in e for e in errors)
+
+    def test_multiple_errors(self):
+        logs = "ModuleNotFoundError: xyz\ncommand not found: foo\n"
+        errors = scan_logs_for_errors(logs)
+        assert len(errors) >= 2
+
+
+class TestGetCheckRunsForSha:
+    """Test SHA-pinned check-run fetching, incl. --paginate concatenated JSON."""
+
+    @patch("verify_green.run_cmd")
+    def test_single_page(self, mock_cmd):
+        def side_effect(cmd):
+            if "nameWithOwner" in " ".join(cmd):
+                return "owner/repo"
+            return json.dumps(
+                {"check_runs": [{"name": "build", "conclusion": "success"}]}
+            )
+
+        mock_cmd.side_effect = side_effect
+        runs = get_check_runs_for_sha("abc123")
+        assert len(runs) == 1
+        assert runs[0]["name"] == "build"
+
+    @patch("verify_green.run_cmd")
+    def test_paginated_concatenated_json(self, mock_cmd):
+        page1 = json.dumps({"check_runs": [{"name": "a"}]})
+        page2 = json.dumps({"check_runs": [{"name": "b"}]})
+
+        def side_effect(cmd):
+            if "nameWithOwner" in " ".join(cmd):
+                return "owner/repo"
+            return page1 + "\n" + page2
+
+        mock_cmd.side_effect = side_effect
+        runs = get_check_runs_for_sha("abc123")
+        assert [r["name"] for r in runs] == ["a", "b"]
+
+
+class TestGetRunIdsForSha:
+    """Test workflow-run id filtering by SHA and completion."""
+
+    @patch("verify_green.run_cmd")
+    def test_filters_wrong_sha_and_incomplete(self, mock_cmd):
+        mock_cmd.return_value = json.dumps(
+            [
+                {"databaseId": 1, "status": "completed", "headSha": "sha_want"},
+                {"databaseId": 2, "status": "completed", "headSha": "sha_other"},
+                {"databaseId": 3, "status": "in_progress", "headSha": "sha_want"},
+            ]
+        )
+        ids = get_run_ids_for_sha("sha_want")
+        assert ids == ["1"]
+
+
+class TestVerifyGreenIntegration:
+    """Integration tests with run_cmd mocked to the REAL gh command shapes:
+    gh pr view --json headRefOid / gh repo view --json nameWithOwner /
+    gh api repos/<slug>/commits/<sha>/check-runs / gh pr diff /
+    gh run list --commit / gh run view <id> --log
+    """
+
+    @staticmethod
+    def make_side_effect(
+        head_sha="sha_123",
+        check_runs=None,
+        diff="",
+        run_ids=None,
+        logs="All tests passed\n",
+    ):
+        check_runs = (
+            check_runs
+            if check_runs is not None
+            else [{"name": "build", "status": "completed", "conclusion": "success"}]
+        )
+        run_ids = run_ids if run_ids is not None else [1]
+
+        def side_effect(cmd):
+            joined = " ".join(str(c) for c in cmd)
+            if "headRefOid" in joined:
+                return json.dumps({"headRefOid": head_sha})
+            if "nameWithOwner" in joined:
+                return "owner/repo"
+            if "check-runs" in joined:
+                return json.dumps({"check_runs": check_runs})
+            if "diff" in joined:
+                return diff
+            if "run list" in joined or ("--commit" in joined):
+                return json.dumps(
+                    [
+                        {"databaseId": rid, "status": "completed", "headSha": head_sha}
+                        for rid in run_ids
+                    ]
+                )
+            if "--log" in joined:
+                return logs
+            return ""
+
+        return side_effect
+
+    @patch("verify_green.run_cmd")
+    def test_stale_sha_fails(self, mock_cmd):
+        """No check-runs against the current head = the green badge was stale."""
+        mock_cmd.side_effect = self.make_side_effect(check_runs=[])
+        verdict = verify_green(123)
+        assert verdict["errors"]
+        assert any("previous head" in str(e) for e in verdict["errors"])
+
+    @patch("verify_green.run_cmd")
+    def test_skipped_check_fails(self, mock_cmd):
+        mock_cmd.side_effect = self.make_side_effect(
+            check_runs=[
+                {"name": "build", "status": "completed", "conclusion": "skipped"}
+            ]
+        )
+        verdict = verify_green(123)
+        assert any("skipped" in str(e).lower() for e in verdict["errors"])
+
+    @patch("verify_green.run_cmd")
+    def test_in_progress_check_fails(self, mock_cmd):
+        mock_cmd.side_effect = self.make_side_effect(
+            check_runs=[{"name": "build", "status": "in_progress", "conclusion": None}]
+        )
+        verdict = verify_green(123)
+        assert any("not completed" in str(e) for e in verdict["errors"])
+
+    @patch("verify_green.run_cmd")
+    def test_missing_test_in_log_fails(self, mock_cmd):
+        mock_cmd.side_effect = self.make_side_effect(
+            diff="+def test_new_feature():\n+    pass\n",
+            logs="test_existing_feature PASSED\n",
+        )
+        verdict = verify_green(123)
+        assert any("not found in" in str(e).lower() for e in verdict["errors"])
+
+    @patch("verify_green.run_cmd")
+    def test_module_error_in_logs_fails(self, mock_cmd):
+        mock_cmd.side_effect = self.make_side_effect(
+            logs="ModuleNotFoundError: no module named foo\n"
+        )
+        verdict = verify_green(123)
+        assert any("ModuleNotFoundError" in str(e) for e in verdict["errors"])
+
+    @patch("verify_green.run_cmd")
+    def test_all_good_passes(self, mock_cmd):
+        mock_cmd.side_effect = self.make_side_effect(
+            diff="+def test_new_feature():\n+    pass\n",
+            logs="test_new_feature PASSED\nAll tests passed\n",
+        )
+        verdict = verify_green(123)
+        assert not verdict["errors"]
+        assert verdict["tests_found_in_log"] == ["test_new_feature"]


### PR DESCRIPTION
## What

The trackable "insights segment": every Claude Code usage-insights report (2026-07-06, 2026-08-09, 2026-08-23) now has an entry in **docs/insights/** with a consolidated implementation-status table, and every actionable recommendation is implemented and distributed cluster-wide.

## Contents

| Area | Files |
|---|---|
| Insights tracker | `docs/insights/README.md` + 3 report entries |
| Cluster-wide distribution | `infra/claude/` — rules, 3 hooks, /resume + /ship skills, idempotent `install.sh` |
| Unfakeable green verdict | `scripts/verify_green.py` — SHA-pinned via `commits/<sha>/check-runs`, no skipped checks, new tests must appear in run logs, fails on silent no-ops |
| Parallel-session claim ledger | `scripts/agent_claim.py` — atomic O_EXCL lease, merged-work preflight, heartbeat, stale reap |
| Discovery | root `CLAUDE.md` pointer section |

## Verification (evidence, not claims)

- 50/50 new tests pass on system python3.9 (`pytest tests/test_verify_green.py tests/test_agent_claim.py`)
- `verify_green.py --self-test` PASS; both scripts `py_compile` clean on 3.9; ruff format+check clean
- `install.sh` tested in a sandboxed HOME: fresh install, idempotent re-run, refuses to run from a temporary worktree (dangling-import guard)
- Both hooks pipe-tested with synthetic payloads; the shared-file guard's live firing proven via sentinel
- gh API surface verified empirically (`gh pr checks --json` does NOT expose `runHeadSha`/`conclusion` — an initial draft fabricated those fields; caught in review and rewritten against `repos/{repo}/commits/{sha}/check-runs`, which is inherently SHA-pinned)

## Hazard ledger

- Pre-existing `tests/` collection errors (5 files, 3.10+ `X | Y` syntax on system 3.9) — untouched by this PR, pre-existing on main | explicitly accepted
- `install.sh` appends an @import to `~/.claude/CLAUDE.md`; nodes that already carry these rules inline (CHARLIE) should remove the inline copies after installing | follow-up on merge
- Leases are filesystem-local (same-machine sessions); cross-node claim coordination would need git-backed leases | deliberately deferred, documented in tracker

## Rollout

After merge, on each node: `git -C ~/factorylm pull && bash ~/factorylm/infra/claude/install.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Au18CpT4tZtgnBt8oDPdPB